### PR TITLE
feat(tui): add read-only action commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,15 @@ jobs:
       - name: Race tests
         run: make test-race
 
+      - name: Go vet
+        run: make vet
+
+      - name: Staticcheck
+        run: make staticcheck
+
+      - name: Gosec static analysis
+        run: make gosec
+
   trunk:
     name: Trunk Check
     runs-on: ubuntu-latest
@@ -131,6 +140,10 @@ jobs:
       - name: Fail on Raycast test failure
         if: ${{ steps.raycast-tests.outcome != 'success' }}
         run: exit 1
+
+      - name: Audit Raycast dependencies
+        run: npm audit --audit-level=moderate
+        working-directory: integrations/raycast
 
       - name: Lint Raycast extension
         run: npm run lint

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GOTESTSUM_VERSION ?= v1.13.0
 GOSEC_VERSION ?= v2.26.1
 STATICCHECK_VERSION ?= v0.7.0
 RAYCAST_DIR ?= integrations/raycast
-GO_PACKAGES ?= $(shell go list ./cmd/... ./internal/...)
+GO_PACKAGES ?= $(shell go list ./cmd/... ./internal/... ./tools/...)
 
 .PHONY: test test-race vet staticcheck gosec go-test-junit test-junit trunk-check trunk-fix trunk-flaky-validate raycast-install raycast-test raycast-test-junit raycast-audit raycast-lint raycast-build raycast-verify verify build install-local clean-reports
 
@@ -25,7 +25,8 @@ gosec:
 
 go-test-junit:
 	mkdir -p $(REPORTS_DIR)
-	go run gotest.tools/gotestsum@$(GOTESTSUM_VERSION) --format testname --junitfile $(REPORTS_DIR)/go-tests.xml -- $(GO_PACKAGES)
+	go run gotest.tools/gotestsum@$(GOTESTSUM_VERSION) --format testname --junitfile $(REPORTS_DIR)/go-tests.raw.xml -- $(GO_PACKAGES)
+	go run ./tools/normalize-go-junit $(REPORTS_DIR)/go-tests.raw.xml $(REPORTS_DIR)/go-tests.xml
 
 test-junit: clean-reports go-test-junit raycast-install
 	cd $(RAYCAST_DIR) && npm run test:junit

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,27 @@
 PREFIX ?= $(HOME)/.local
 REPORTS_DIR ?= reports
 GOTESTSUM_VERSION ?= v1.13.0
+GOSEC_VERSION ?= v2.26.1
+STATICCHECK_VERSION ?= v0.7.0
 RAYCAST_DIR ?= integrations/raycast
 GO_PACKAGES ?= $(shell go list ./cmd/... ./internal/...)
 
-.PHONY: test test-race go-test-junit test-junit trunk-check trunk-fix trunk-flaky-validate raycast-install raycast-test raycast-test-junit raycast-lint raycast-build raycast-verify verify build install-local clean-reports
+.PHONY: test test-race vet staticcheck gosec go-test-junit test-junit trunk-check trunk-fix trunk-flaky-validate raycast-install raycast-test raycast-test-junit raycast-audit raycast-lint raycast-build raycast-verify verify build install-local clean-reports
 
 test:
 	go test $(GO_PACKAGES)
 
 test-race:
 	go test -race $(GO_PACKAGES)
+
+vet:
+	go vet $(GO_PACKAGES)
+
+staticcheck:
+	go run honnef.co/go/tools/cmd/staticcheck@$(STATICCHECK_VERSION) $(GO_PACKAGES)
+
+gosec:
+	go run github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION) -exclude-generated -exclude-dir=$(RAYCAST_DIR)/node_modules -exclude-dir=$(RAYCAST_DIR)/dist ./...
 
 go-test-junit:
 	mkdir -p $(REPORTS_DIR)
@@ -37,15 +48,18 @@ raycast-test:
 raycast-test-junit:
 	cd $(RAYCAST_DIR) && npm run test:junit
 
+raycast-audit:
+	cd $(RAYCAST_DIR) && npm audit --audit-level=moderate
+
 raycast-lint:
 	cd $(RAYCAST_DIR) && npm run lint
 
 raycast-build:
 	cd $(RAYCAST_DIR) && npm run build
 
-raycast-verify: raycast-install raycast-test raycast-lint raycast-build
+raycast-verify: raycast-install raycast-test raycast-audit raycast-lint raycast-build
 
-verify: test test-race test-junit trunk-flaky-validate trunk-check raycast-lint raycast-build
+verify: test test-race vet staticcheck gosec test-junit trunk-flaky-validate trunk-check raycast-audit raycast-lint raycast-build
 
 build:
 	go build -o bin/nightward ./cmd/nightward

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Nightward answers the practical questions first:
 - Bubble Tea TUI with dashboard, inventory, findings, fix plan, and backup preview tabs.
 - `nightward` canonical command plus `nw` short alias.
 - Redacted JSON for automation and CI.
-- MCP findings for unpinned package execution, shell wrappers, sensitive env keys, broad filesystem access, token paths, parse failures, and unknown server shapes.
+- MCP findings for unpinned package execution, shell wrappers, sensitive env keys, sensitive headers, local endpoints, broad filesystem access, token paths, parse failures, and unknown server shapes.
+- Scan summaries separate inventory buckets from finding buckets: item classification/risk/tool counts are distinct from finding severity/rule/tool counts.
 - Plan-only remediation metadata: fix kind, confidence, risk, review requirement, impact, and steps.
 - SARIF output for GitHub code scanning.
 - Optional `.nightward.yml` policy config with reason-required ignores.
@@ -150,6 +151,8 @@ Nightward does not apply fixes yet. "Autofix" currently means structured, review
 
 Secret values are never emitted in scan JSON, findings output, fix-plan JSON, Markdown exports, SARIF, or TUI detail text.
 
+`scan --json` is pre-1.0 and may make breaking shape improvements. The current summary schema uses explicit keys such as `items_by_classification`, `items_by_risk`, `findings_by_severity`, and `findings_by_rule` so item risk is not confused with finding severity.
+
 ## TUI
 
 The default `nightward` / `nw` command opens the TUI:
@@ -238,7 +241,9 @@ make verify
 go run ./cmd/nightward --help
 go run ./cmd/nw --help
 go run ./cmd/nw scan --json
+go run ./cmd/nw scan --json | jq '.summary'
 go run ./cmd/nw findings list --json
+go run ./cmd/nw findings list --json | jq '[.[] | select(.rule=="mcp_unknown_command")]'
 go run ./cmd/nw fix plan --all --json
 go run ./cmd/nw fix preview --all --format markdown
 go run ./cmd/nw policy sarif --output /tmp/nightward.sarif

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Nightward is a local-first TUI and CLI for auditing AI agent and devtool state before it leaks into dotfiles.
 
-It scans common Codex, Claude, Cursor, Windsurf, VS Code, Raycast, JetBrains, Zed, Continue, Cline/Roo, Aider, OpenCode, Goose, LM Studio, Ollama/Open WebUI, Neovim, and MCP config locations; classifies what is portable versus local-only or secret; highlights MCP security findings; and produces redacted fix plans, fix previews, SARIF policy output, snapshot plans, and dry-run backup plans.
+It scans common Codex, Claude, Cursor, Windsurf, VS Code, Raycast, JetBrains, Zed, Continue, Cline/Roo, Aider, OpenCode, Goose, LM Studio, Ollama/Open WebUI, Neovim, MCP config locations, and repo/workspace AI config; classifies what is portable versus local-only or secret; highlights MCP security findings; and produces redacted analysis signals, fix plans, fix previews, SARIF policy output, snapshot plans, and dry-run backup plans.
 
 Nightward does not mutate agent configs. It only writes explicit report/SARIF files when requested and user-level schedule files through explicit schedule install/remove commands.
 
@@ -26,18 +26,22 @@ Nightward answers the practical questions first:
 
 ## Highlights
 
-- Bubble Tea TUI with dashboard, inventory, findings, fix plan, and backup preview tabs.
+- Bubble Tea TUI with dashboard, inventory, findings, analysis, fix plan, and backup preview tabs.
 - `nightward` canonical command plus `nw` short alias.
 - Redacted JSON for automation and CI.
+- HOME scanning for local machines and `--workspace` scanning for CI, Trunk, and dotfiles repos.
 - MCP findings for unpinned package execution, shell wrappers, sensitive env keys, sensitive headers, local endpoints, broad filesystem access, token paths, parse failures, and unknown server shapes.
+- Offline analysis signals for supply-chain, secret exposure, filesystem scope, network exposure, execution risk, machine-local, and app-owned state review.
+- Optional provider framework for local and online-capable tools; providers never auto-install and online-capable providers stay blocked unless explicitly enabled.
 - Scan summaries separate inventory buckets from finding buckets: item classification/risk/tool counts are distinct from finding severity/rule/tool counts.
 - Plan-only remediation metadata: fix kind, confidence, risk, review requirement, impact, and steps.
 - SARIF output for GitHub code scanning.
+- Importable Trunk plugin definition for `nightward-policy` and `nightward-analyze` after release tags exist.
 - Optional `.nightward.yml` policy config with reason-required ignores.
 - Redacted patch previews for parseable MCP config fixes.
 - Read-only snapshot plan/diff commands.
 - Reusable GitHub Action for scan, policy, and SARIF modes.
-- Read-only Raycast extension for Dashboard, Findings, Explain Finding, Fix Plan export, and report-folder access.
+- Read-only Raycast extension for Dashboard, Findings, Analysis, Provider Doctor, Explain Finding/Signal, Fix Plan/Analysis export, and report-folder access.
 - User-level nightly scan scheduling for macOS launchd, Linux systemd user timers, and cron text fallback.
 - No telemetry, no cloud dashboard, no network calls from Nightward runtime, and no live config mutation.
 
@@ -60,10 +64,16 @@ Open the TUI:
 nw
 ```
 
-Scan and emit redacted JSON:
+Scan local HOME state and emit redacted JSON:
 
 ```sh
 nw scan --json
+```
+
+Scan a repo/workspace instead of HOME:
+
+```sh
+nw scan --workspace . --json
 ```
 
 Check local assumptions:
@@ -87,6 +97,23 @@ nw fix plan --rule mcp_secret_env
 nw fix preview --rule mcp_secret_env --format diff
 nw fix preview --all --format markdown
 nw fix export --format markdown
+```
+
+Run offline analysis and provider checks:
+
+```sh
+nw analyze --all --json
+nw analyze --all --workspace . --json
+nw analyze package npm:@modelcontextprotocol/server-filesystem --json
+nw trust explain mcp_unpinned_package-abc123
+nw providers list --json
+nw providers doctor --with socket --json
+```
+
+Online-capable providers remain blocked until explicitly allowed:
+
+```sh
+nw providers doctor --with socket --online --json
 ```
 
 Create or explain policy config:
@@ -115,6 +142,8 @@ Run policy checks or generate SARIF:
 ```sh
 nw policy check --strict --json
 nw policy sarif --output nightward.sarif
+nw policy check --workspace . --include-analysis --strict --json
+nw policy sarif --workspace . --include-analysis --output -
 ```
 
 Preview scheduled nightly scans:
@@ -153,6 +182,14 @@ Secret values are never emitted in scan JSON, findings output, fix-plan JSON, Ma
 
 `scan --json` is pre-1.0 and may make breaking shape improvements. The current summary schema uses explicit keys such as `items_by_classification`, `items_by_risk`, `findings_by_severity`, and `findings_by_rule` so item risk is not confused with finding severity.
 
+## Analysis Model
+
+`nw analyze` turns scan findings and classifications into explainable signals. It does not claim a package, server, binary, or URL is safe. It reports what Nightward can prove from local structure, why it matters, and how confident the signal is.
+
+Default analysis is offline and built in. Optional providers such as `gitleaks`, `trufflehog`, `semgrep`, `trivy`, `osv-scanner`, and `socket` are discovered by `providers doctor`; Nightward does not install them or call online services unless a user explicitly selects providers and opts into network-capable behavior.
+
+Policy config can enable analysis and selected provider posture with `include_analysis`, `analysis_threshold`, `analysis_providers`, and `allow_online_providers`.
+
 ## TUI
 
 The default `nightward` / `nw` command opens the TUI:
@@ -160,12 +197,13 @@ The default `nightward` / `nw` command opens the TUI:
 - Dashboard: scan counts and schedule status
 - Inventory: discovered paths by tool, classification, and risk
 - Findings: severity/tool/rule filters with a selected-finding detail pane
+- Analysis: offline risk signals and provider warning summary
 - Fix Plan: safe/review/blocked remediation groups
 - Backup Plan: private-dotfiles dry-run preview
 
 Keyboard shortcuts:
 
-- `1`-`5`: switch tabs
+- `1`-`6`: switch tabs
 - arrow keys or `h`/`j`/`k`/`l`: navigate
 - `/`: search findings
 - `s`, `t`, `r`: cycle finding severity, tool, and rule filters
@@ -189,6 +227,17 @@ Nightward can run as a local GitHub Action in scan, policy, or SARIF mode:
 
 See [docs/action.md](docs/action.md) for inputs, outputs, and SARIF upload examples.
 
+## Trunk Plugin
+
+Nightward includes an in-repo `plugin.yaml` for Trunk Check. After release tags exist, users can import the plugin and enable repo/workspace policy scans:
+
+```sh
+trunk plugins add --id nightward https://github.com/JSONbored/nightward v0.1.0
+trunk check enable nightward-policy
+```
+
+`nightward-policy` emits SARIF from `nw policy sarif --workspace ${workspace} --output -`. `nightward-analyze` adds offline analysis signals with `--include-analysis`.
+
 ## Raycast Extension
 
 The read-only Raycast extension lives in [integrations/raycast](integrations/raycast).
@@ -204,8 +253,12 @@ Commands:
 
 - `Nightward Dashboard`
 - `Nightward Findings`
+- `Nightward Analysis`
+- `Nightward Provider Doctor`
 - `Explain Nightward Finding`
+- `Explain Nightward Signal`
 - `Export Nightward Fix Plan`
+- `Export Nightward Analysis`
 - `Open Nightward Reports`
 
 The extension shells out to `nw` or `nightward`, renders redacted output, copies an explicitly requested fix-plan export, and opens the local reports folder. It does not mutate agent configs or install schedules.
@@ -241,12 +294,16 @@ make verify
 go run ./cmd/nightward --help
 go run ./cmd/nw --help
 go run ./cmd/nw scan --json
+go run ./cmd/nw scan --workspace . --json
 go run ./cmd/nw scan --json | jq '.summary'
 go run ./cmd/nw findings list --json
 go run ./cmd/nw findings list --json | jq '[.[] | select(.rule=="mcp_unknown_command")]'
+go run ./cmd/nw analyze --all --json
+go run ./cmd/nw providers doctor --json
 go run ./cmd/nw fix plan --all --json
 go run ./cmd/nw fix preview --all --format markdown
 go run ./cmd/nw policy sarif --output /tmp/nightward.sarif
+go run ./cmd/nw policy sarif --workspace . --include-analysis --output -
 go run ./cmd/nw schedule install --preset nightly --dry-run
 ```
 
@@ -266,6 +323,7 @@ go run golang.org/x/vuln/cmd/govulncheck@latest ./...
 - [Support](SUPPORT.md)
 - [Roadmap](ROADMAP.md)
 - [Adapters](docs/adapters.md)
+- [Analysis](docs/analysis.md)
 - [Remediation](docs/remediation.md)
 - [Testing](docs/testing.md)
 - [Dependency maintenance](docs/dependency-maintenance.md)

--- a/README.md
+++ b/README.md
@@ -167,7 +167,9 @@ Keyboard shortcuts:
 - `/`: search findings
 - `s`, `t`, `r`: cycle finding severity, tool, and rule filters
 - `x`: clear finding filters
-- `c`, `e`, `o`: show copy/export/docs action hints
+- `c`: copy the selected path, recommendation, or fix step to the clipboard
+- `e`: export a redacted fix plan to `~/.local/state/nightward/exports`
+- `o`: open remediation docs for the selected finding or fix
 - `?`: help
 - `q` or `esc`: quit
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,7 +20,6 @@ Nightward is intentionally staged. The scanner and policy model need to stay tru
 ## Next
 
 - More MCP config shapes for Codex, Claude Code, and editor integrations.
-- Richer TUI actions with real clipboard/export/open-doc behavior behind explicit keypresses.
 - Raycast screenshots, store metadata, and manual development-mode smoke after the first release candidate.
 - Golden SARIF snapshots and broader no-write tests.
 - Validate GoReleaser on the first release candidate tag.

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,14 @@ inputs:
     description: HOME path Nightward should scan.
     required: false
     default: ""
+  workspace:
+    description: Repository/workspace path Nightward should scan instead of HOME.
+    required: false
+    default: ""
+  include-analysis:
+    description: Include offline analysis signals in policy or SARIF modes.
+    required: false
+    default: "false"
 
 outputs:
   findings-count:
@@ -53,6 +61,8 @@ runs:
         INPUT_STRICT: ${{ inputs.strict }}
         INPUT_OUTPUT: ${{ inputs.output }}
         INPUT_HOME: ${{ inputs.home }}
+        INPUT_WORKSPACE: ${{ inputs.workspace }}
+        INPUT_INCLUDE_ANALYSIS: ${{ inputs.include-analysis }}
       run: |
         set -euo pipefail
 
@@ -61,6 +71,8 @@ runs:
         strict="${INPUT_STRICT}"
         output="${INPUT_OUTPUT}"
         scan_home="${INPUT_HOME}"
+        scan_workspace="${INPUT_WORKSPACE:-}"
+        include_analysis="${INPUT_INCLUDE_ANALYSIS}"
 
         if [[ -n "${scan_home}" ]]; then
           export NIGHTWARD_HOME="${scan_home}"
@@ -70,15 +82,23 @@ runs:
         if [[ -n "${config}" ]]; then
           config_args+=(--config "${config}")
         fi
+        workspace_args=()
+        if [[ -n "${scan_workspace}" ]]; then
+          workspace_args+=(--workspace "${scan_workspace}")
+        fi
+        analysis_args=()
+        if [[ "${include_analysis}" == "true" ]]; then
+          analysis_args+=(--include-analysis)
+        fi
 
         cd "${GITHUB_ACTION_PATH}"
         case "${mode}" in
           scan)
-            go run ./cmd/nw scan --json --output "${GITHUB_WORKSPACE}/${output}"
+            go run ./cmd/nw scan "${workspace_args[@]}" --json --output "${GITHUB_WORKSPACE}/${output}"
             echo "output=${output}" >>"${GITHUB_OUTPUT}"
             ;;
           policy)
-            args=(policy check "${config_args[@]}" --json)
+            args=(policy check "${config_args[@]}" "${workspace_args[@]}" "${analysis_args[@]}" --json)
             if [[ "${strict}" == "true" ]]; then
               args+=(--strict)
             fi
@@ -90,7 +110,7 @@ runs:
             echo "output=nightward-policy.json" >>"${GITHUB_OUTPUT}"
             ;;
           sarif)
-            go run ./cmd/nw policy sarif "${config_args[@]}" --output "${GITHUB_WORKSPACE}/${output}"
+            go run ./cmd/nw policy sarif "${config_args[@]}" "${workspace_args[@]}" "${analysis_args[@]}" --output "${GITHUB_WORKSPACE}/${output}"
             echo "output=${output}" >>"${GITHUB_OUTPUT}"
             ;;
           *)

--- a/cmd/nightward/main.go
+++ b/cmd/nightward/main.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/shadowbook/nightward/internal/cli"
+	"github.com/jsonbored/nightward/internal/cli"
 )
 
 func main() {

--- a/cmd/nw/main.go
+++ b/cmd/nw/main.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/shadowbook/nightward/internal/cli"
+	"github.com/jsonbored/nightward/internal/cli"
 )
 
 func main() {

--- a/docs/action.md
+++ b/docs/action.md
@@ -24,6 +24,8 @@ Inputs:
 - `strict`: fail policy checks on medium or higher findings
 - `output`: output path for scan JSON or SARIF
 - `home`: optional HOME override for fixture scans
+- `workspace`: optional repository/workspace path to scan instead of HOME
+- `include-analysis`: include offline analysis signals in policy or SARIF modes
 
 Outputs:
 
@@ -32,3 +34,14 @@ Outputs:
 - `output`
 
 The action runs Nightward locally. It does not upload findings unless your workflow separately uploads artifacts or SARIF.
+
+For repository CI, prefer workspace mode:
+
+```yaml
+- uses: JSONbored/nightward@v0.1.0
+  with:
+    mode: sarif
+    workspace: ${{ github.workspace }}
+    include-analysis: "true"
+    output: nightward.sarif
+```

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -42,3 +42,5 @@ New adapters must include:
 - conservative classification for app databases, auth, model blobs, caches, and extension storage
 
 If an adapter parses executable config, its findings should include remediation metadata and never emit secret values.
+
+MCP adapters should treat URL-shaped remote servers as first-class config, not as unknown commands. They should still flag sensitive headers and local/private endpoints without printing header values or URL path/query details.

--- a/docs/analysis.md
+++ b/docs/analysis.md
@@ -1,0 +1,66 @@
+# Analysis
+
+Nightward analysis turns scan findings and classified paths into explainable risk signals.
+
+Default behavior is offline:
+
+```sh
+nw analyze --all --json
+nw analyze --all --workspace . --json
+```
+
+Analysis output includes:
+
+- `subjects`: findings, inventory items, or packages under review
+- `signals`: severity, category, confidence, evidence, and recommended action
+- `providers`: built-in and optional provider status
+- `summary`: counts by severity, category, and provider
+
+Nightward avoids "safe" claims. A clean analysis means Nightward found no known risk signals from the enabled providers, not that the subject is trustworthy.
+
+## Providers
+
+The built-in `nightward` provider is always offline and enabled by default. Optional providers are discovered but not installed or run automatically:
+
+- `gitleaks`
+- `trufflehog`
+- `semgrep`
+- `trivy`
+- `osv-scanner`
+- `socket`
+
+Check provider posture:
+
+```sh
+nw providers list --json
+nw providers doctor --json
+nw providers doctor --with socket --json
+```
+
+Online-capable providers remain blocked unless explicitly allowed:
+
+```sh
+nw providers doctor --with socket --online --json
+```
+
+Policy/SARIF config can opt into provider posture:
+
+```yaml
+include_analysis: true
+analysis_threshold: high
+analysis_providers:
+  - socket
+allow_online_providers: false
+```
+
+## Policy And SARIF
+
+Analysis signals are advisory unless included explicitly:
+
+```sh
+nw policy check --include-analysis --json
+nw policy sarif --include-analysis --output nightward.sarif
+nw policy sarif --workspace . --include-analysis --output -
+```
+
+SARIF analysis rules are emitted under `nightward/analyze/<rule>`.

--- a/docs/ci-security.md
+++ b/docs/ci-security.md
@@ -4,7 +4,7 @@ Nightward's CI is meant to prove the project is serious about the same safety po
 
 ## Workflows
 
-- `ci.yml`: Go tests, JUnit reports, local JUnit shape validation, gated Trunk Flaky Tests uploads, Trunk Check, Raycast extension tests/build, Gitleaks, govulncheck, and OSV dependency scanning.
+- `ci.yml`: Go tests, race tests, `go vet`, `staticcheck`, `gosec`, JUnit reports, local JUnit shape validation, gated Trunk Flaky Tests uploads, Trunk Check, Raycast extension tests/build/audit, Gitleaks, govulncheck, and OSV dependency scanning.
 - `nightward-policy.yml`: generates Nightward SARIF from a fixture home and uploads it to GitHub code scanning.
 - `plugin.yaml`: defines Trunk Check linters for workspace policy and analysis SARIF once release tags are available.
 - `scorecard.yml`: runs OpenSSF Scorecard and uploads SARIF.

--- a/docs/ci-security.md
+++ b/docs/ci-security.md
@@ -6,6 +6,7 @@ Nightward's CI is meant to prove the project is serious about the same safety po
 
 - `ci.yml`: Go tests, JUnit reports, local JUnit shape validation, gated Trunk Flaky Tests uploads, Trunk Check, Raycast extension tests/build, Gitleaks, govulncheck, and OSV dependency scanning.
 - `nightward-policy.yml`: generates Nightward SARIF from a fixture home and uploads it to GitHub code scanning.
+- `plugin.yaml`: defines Trunk Check linters for workspace policy and analysis SARIF once release tags are available.
 - `scorecard.yml`: runs OpenSSF Scorecard and uploads SARIF.
 - `release.yml`: publishes signed GoReleaser artifacts from strict `vX.Y.Z` tags.
 - `renovate.json`: manages Go modules, Raycast npm packages, pinned GitHub Actions, local tool pins, and release tooling updates.
@@ -20,6 +21,20 @@ Nightward's CI is meant to prove the project is serious about the same safety po
 - Never make flaky-test quarantining a default CI behavior.
 - Use Renovate instead of Dependabot whenever possible.
 - Keep dependency PRs reviewed; do not enable broad automerge by default.
+
+## Trunk Plugin Notes
+
+The in-repo plugin exposes:
+
+- `nightward-policy`: runs `nw policy sarif --workspace ${workspace} --output -`
+- `nightward-analyze`: runs `nw policy sarif --workspace ${workspace} --include-analysis --output -`
+
+Users should import a pinned Nightward tag, not a moving branch:
+
+```sh
+trunk plugins add --id nightward https://github.com/JSONbored/nightward v0.1.0
+trunk check enable nightward-policy
+```
 
 ## Release Hardening Backlog
 

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -8,6 +8,7 @@ Nightward is designed around local custody. The scanner inspects local file meta
 - No analytics.
 - No cloud dashboard.
 - No network calls from Nightward runtime.
+- Offline analysis is the default. Online-capable providers stay blocked unless the user explicitly passes `--online` or opts in through policy/config in a future release.
 - No live backup, restore, Git push, or secret copy.
 - No agent config mutation in scan, doctor, findings, fix, policy, or backup-plan commands.
 - The TUI can copy text, export redacted fix-plan Markdown, and open docs only after explicit keypresses.
@@ -20,6 +21,7 @@ Nightward writes only when explicitly asked:
 - `scan --output FILE`
 - `scan --output-dir DIR`
 - `policy sarif --output FILE`
+- `policy sarif --output -` writes SARIF to stdout only.
 - TUI `e` key: redacted fix-plan export under `~/.local/state/nightward/exports`
 - `schedule install`
 - `schedule remove`
@@ -37,7 +39,9 @@ Nightward must not emit secret values in:
 - scan JSON
 - findings output
 - fix-plan JSON
+- analysis JSON
 - Markdown fix exports
+- Markdown analysis exports
 - SARIF output
 - TUI detail views
 - TUI fix-plan exports
@@ -52,6 +56,8 @@ Secret header handling follows the same rule: header names may be emitted, but h
 MCP argument evidence redacts secret-looking assignments and flag values, such as `--api-key value`, `TOKEN=value`, and `Authorization: value`.
 
 Remote MCP URL evidence is structural only. Nightward records scheme and host for review, strips path/query details, and does not call the endpoint.
+
+Provider doctor output is intentionally about availability and privacy posture. It does not run optional local scanners by default, install missing tools, or send package/file metadata to online services.
 
 ## What Still Needs Human Review
 

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -47,10 +47,14 @@ Secret env handling distinguishes:
 - env key references, such as `${API_TOKEN}`, which become guidance-only remediation
 - inline secret values, which become higher-risk externalization plans
 
+Secret header handling follows the same rule: header names may be emitted, but header values are never emitted. Inline values become higher-risk `mcp_secret_header` findings; environment references become guidance-only remediation.
+
 MCP argument evidence redacts secret-looking assignments and flag values, such as `--api-key value`, `TOKEN=value`, and `Authorization: value`.
+
+Remote MCP URL evidence is structural only. Nightward records scheme and host for review, strips path/query details, and does not call the endpoint.
 
 ## What Still Needs Human Review
 
-Nightward can detect obvious local risk, but it cannot know user intent. Findings such as broad filesystem mounts, local token paths, shell wrappers, and unknown MCP server shapes should be reviewed before syncing.
+Nightward can detect obvious local risk, but it cannot know user intent. Findings such as broad filesystem mounts, local token paths, shell wrappers, local MCP endpoints, and unknown MCP server shapes should be reviewed before syncing.
 
 If a report contains private state, treat that as a bug and follow [SECURITY.md](../SECURITY.md).

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -10,6 +10,7 @@ Nightward is designed around local custody. The scanner inspects local file meta
 - No network calls from Nightward runtime.
 - No live backup, restore, Git push, or secret copy.
 - No agent config mutation in scan, doctor, findings, fix, policy, or backup-plan commands.
+- The TUI can copy text, export redacted fix-plan Markdown, and open docs only after explicit keypresses.
 - The Raycast extension calls only read-only Nightward commands and explicit clipboard/report-folder actions.
 
 ## Write Paths
@@ -19,10 +20,13 @@ Nightward writes only when explicitly asked:
 - `scan --output FILE`
 - `scan --output-dir DIR`
 - `policy sarif --output FILE`
+- TUI `e` key: redacted fix-plan export under `~/.local/state/nightward/exports`
 - `schedule install`
 - `schedule remove`
 
 Schedule install/remove writes only user-level scheduler files. It does not copy configs, secrets, dotfiles, or reports into Git.
+
+The TUI docs action opens an http(s) documentation URL through the OS default opener after the user presses `o`; Nightward itself does not fetch docs content.
 
 The Raycast extension does not add a Nightward config write path. `Export Nightward Fix Plan` copies redacted Markdown to the clipboard after the user invokes that command. `Open Nightward Reports` opens the existing reports folder and does not create it.
 
@@ -36,6 +40,7 @@ Nightward must not emit secret values in:
 - Markdown fix exports
 - SARIF output
 - TUI detail views
+- TUI fix-plan exports
 
 Secret env handling distinguishes:
 

--- a/docs/raycast-extension.md
+++ b/docs/raycast-extension.md
@@ -12,8 +12,12 @@ integrations/raycast
 
 - `Nightward Dashboard`: scan counts, schedule status, adapter summary, and top findings.
 - `Nightward Findings`: searchable findings with a severity filter, detail pane, and copy/open-doc actions.
+- `Nightward Analysis`: offline analysis signals with severity, confidence, evidence, and recommended action.
+- `Nightward Provider Doctor`: optional provider availability and privacy posture.
 - `Explain Nightward Finding`: detail view for a known finding ID.
+- `Explain Nightward Signal`: analysis signal view for a known finding ID.
 - `Export Nightward Fix Plan`: copies `nw fix export --all --format markdown`.
+- `Export Nightward Analysis`: copies a redacted offline analysis Markdown report.
 - `Open Nightward Reports`: opens `~/.local/state/nightward/reports` when it already exists.
 
 ## Preferences
@@ -31,6 +35,9 @@ The extension uses `execFile`, not a shell, for local Nightward commands. It cal
 - `findings explain <id> --json`
 - `fix plan --all --json`
 - `fix export --all --format markdown`
+- `analyze --all --json`
+- `analyze finding <id> --json`
+- `providers doctor --json`
 
 It does not call schedule install/remove, backup writes, snapshot writes, restore, Git, or any config mutation command.
 

--- a/docs/remediation.md
+++ b/docs/remediation.md
@@ -17,6 +17,28 @@ Nightward remediation is plan-only. It recommends changes, explains risk, and ca
 
 Package pinning does not guess versions. Choose a reviewed version from the upstream registry or release notes, then edit the package token manually.
 
+## Rule Guidance
+
+### mcp_secret_env
+
+Move inline secret values out of agent config. Keep only env key names, setup prerequisites, or environment interpolation references in portable files.
+
+### mcp_unpinned_package
+
+Pin package-executor commands such as `npx`, `uvx`, or `pipx` to reviewed package versions before syncing MCP config.
+
+### mcp_shell_command
+
+Replace simple shell passthrough wrappers with direct executable invocation. Review compound shell commands manually because they may depend on local shell startup files or expand secrets.
+
+### mcp_broad_filesystem
+
+Replace broad filesystem mounts with explicit project or data paths after confirming the server's real access requirement.
+
+### mcp_unknown_command
+
+Review unsupported MCP server shapes manually. Add an explicit command where the client supports it, or open an adapter issue with a redacted config example.
+
 ## Policy Ignores
 
 Policy ignores must include a reason:

--- a/docs/remediation.md
+++ b/docs/remediation.md
@@ -23,6 +23,14 @@ Package pinning does not guess versions. Choose a reviewed version from the upst
 
 Move inline secret values out of agent config. Keep only env key names, setup prerequisites, or environment interpolation references in portable files.
 
+### mcp_secret_header
+
+Move sensitive remote MCP header values out of agent config. Keep only header names, setup prerequisites, or environment interpolation references in portable files.
+
+### mcp_local_endpoint
+
+Move loopback, private-network, or machine-local MCP URLs into local-only overlays unless the endpoint is intentionally portable and documented.
+
 ### mcp_unpinned_package
 
 Pin package-executor commands such as `npx`, `uvx`, or `pipx` to reviewed package versions before syncing MCP config.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -41,7 +41,7 @@ make verify
 
 `make test-junit` writes:
 
-- `reports/go-tests.xml` from Go tests with `gotestsum`
+- `reports/go-tests.xml` from Go tests with `gotestsum`, normalized to include testcase file paths
 - `reports/junit/raycast.xml` from the Raycast extension Node tests
 
 `make trunk-flaky-validate` runs:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -26,7 +26,8 @@ make verify
 - Adapter tests use temporary HOME directories and fixture config files.
 - CLI no-write tests prove read-only commands do not mutate HOME.
 - Redaction tests must cover scan JSON, policy output, SARIF, Markdown exports, fix previews, and TUI text.
-- Golden-style tests should stay stable for JSON/SARIF shape, not timestamps or host-specific paths.
+- Golden-style tests should stay stable for JSON/SARIF shape, not timestamps or host-specific paths. Scan-summary goldens must keep item buckets separate from finding buckets.
+- MCP fixture tests should cover command servers, URL-shaped servers, sensitive headers, local endpoints, and unsupported shapes.
 - Scheduler tests verify generated launchd, systemd user timer, and cron text without installing schedules.
 - TUI action tests cover clipboard/open command construction and private redacted fix-plan exports.
 - Raycast extension tests cover pure redaction/formatting helpers and safe command execution wrappers.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,6 +28,7 @@ make verify
 - Redaction tests must cover scan JSON, policy output, SARIF, Markdown exports, fix previews, and TUI text.
 - Golden-style tests should stay stable for JSON/SARIF shape, not timestamps or host-specific paths.
 - Scheduler tests verify generated launchd, systemd user timer, and cron text without installing schedules.
+- TUI action tests cover clipboard/open command construction and private redacted fix-plan exports.
 - Raycast extension tests cover pure redaction/formatting helpers and safe command execution wrappers.
 
 ## Trunk Flaky Tests

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,6 +7,9 @@ Nightward treats read-only behavior, redaction, and policy stability as release 
 ```sh
 make test
 make test-race
+make vet
+make staticcheck
+make gosec
 make test-junit
 make trunk-flaky-validate
 make trunk-check
@@ -31,6 +34,8 @@ make verify
 - Scheduler tests verify generated launchd, systemd user timer, and cron text without installing schedules.
 - TUI action tests cover clipboard/open command construction and private redacted fix-plan exports.
 - Raycast extension tests cover pure redaction/formatting helpers and safe command execution wrappers.
+- `go vet`, `staticcheck`, and `gosec` are part of the local verification bar. `#nosec` comments must include a narrow reason tied to an intentional local CLI behavior.
+- Raycast dependency audits run with `npm audit --audit-level=moderate`.
 
 ## Trunk Flaky Tests
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/shadowbook/nightward
+module github.com/jsonbored/nightward
 
 go 1.25.9
 

--- a/integrations/raycast/package.json
+++ b/integrations/raycast/package.json
@@ -45,6 +45,20 @@
       "keywords": ["findings", "mcp", "security", "privacy", "fix"]
     },
     {
+      "name": "analysis",
+      "title": "Nightward Analysis",
+      "description": "Browse offline analysis signals and provider status.",
+      "mode": "view",
+      "keywords": ["analysis", "signals", "security", "privacy", "trust"]
+    },
+    {
+      "name": "provider-doctor",
+      "title": "Nightward Provider Doctor",
+      "description": "Check optional local and online-capable analysis providers.",
+      "mode": "view",
+      "keywords": ["providers", "doctor", "security", "privacy"]
+    },
+    {
       "name": "explain-finding",
       "title": "Explain Nightward Finding",
       "description": "Open a detailed explanation for one Nightward finding ID.",
@@ -60,11 +74,33 @@
       ]
     },
     {
+      "name": "explain-signal",
+      "title": "Explain Nightward Signal",
+      "description": "Open the analysis signal for a Nightward finding ID.",
+      "mode": "view",
+      "keywords": ["explain", "signal", "trust", "analysis"],
+      "arguments": [
+        {
+          "name": "findingId",
+          "placeholder": "Finding ID",
+          "type": "text",
+          "required": true
+        }
+      ]
+    },
+    {
       "name": "export-fix-plan",
       "title": "Export Nightward Fix Plan",
       "description": "Copy the redacted Nightward fix plan markdown to the clipboard.",
       "mode": "no-view",
       "keywords": ["fix", "export", "clipboard", "markdown"]
+    },
+    {
+      "name": "export-analysis",
+      "title": "Export Nightward Analysis",
+      "description": "Copy the redacted offline analysis report markdown to the clipboard.",
+      "mode": "no-view",
+      "keywords": ["analysis", "export", "clipboard", "markdown"]
     },
     {
       "name": "open-report-folder",

--- a/integrations/raycast/raycast-env.d.ts
+++ b/integrations/raycast/raycast-env.d.ts
@@ -22,10 +22,18 @@ declare namespace Preferences {
   export type Dashboard = ExtensionPreferences & {}
   /** Preferences accessible in the `findings` command */
   export type Findings = ExtensionPreferences & {}
+  /** Preferences accessible in the `analysis` command */
+  export type Analysis = ExtensionPreferences & {}
+  /** Preferences accessible in the `provider-doctor` command */
+  export type ProviderDoctor = ExtensionPreferences & {}
   /** Preferences accessible in the `explain-finding` command */
   export type ExplainFinding = ExtensionPreferences & {}
+  /** Preferences accessible in the `explain-signal` command */
+  export type ExplainSignal = ExtensionPreferences & {}
   /** Preferences accessible in the `export-fix-plan` command */
   export type ExportFixPlan = ExtensionPreferences & {}
+  /** Preferences accessible in the `export-analysis` command */
+  export type ExportAnalysis = ExtensionPreferences & {}
   /** Preferences accessible in the `open-report-folder` command */
   export type OpenReportFolder = ExtensionPreferences & {}
 }
@@ -35,13 +43,24 @@ declare namespace Arguments {
   export type Dashboard = {}
   /** Arguments passed to the `findings` command */
   export type Findings = {}
+  /** Arguments passed to the `analysis` command */
+  export type Analysis = {}
+  /** Arguments passed to the `provider-doctor` command */
+  export type ProviderDoctor = {}
   /** Arguments passed to the `explain-finding` command */
   export type ExplainFinding = {
   /** Finding ID */
   "findingId": string
 }
+  /** Arguments passed to the `explain-signal` command */
+  export type ExplainSignal = {
+  /** Finding ID */
+  "findingId": string
+}
   /** Arguments passed to the `export-fix-plan` command */
   export type ExportFixPlan = {}
+  /** Arguments passed to the `export-analysis` command */
+  export type ExportAnalysis = {}
   /** Arguments passed to the `open-report-folder` command */
   export type OpenReportFolder = {}
 }

--- a/integrations/raycast/src/analysis.tsx
+++ b/integrations/raycast/src/analysis.tsx
@@ -1,0 +1,149 @@
+import {
+  Action,
+  ActionPanel,
+  Color,
+  Detail,
+  Icon,
+  List,
+  getPreferenceValues,
+} from "@raycast/api";
+import { usePromise } from "@raycast/utils";
+import {
+  analysisMarkdown,
+  severityColor,
+  signalMarkdown,
+  sortedSignals,
+} from "./format";
+import { analysisReport, normalizePreferences } from "./nightward";
+import type { AnalysisReport, AnalysisSignal } from "./types";
+
+const docsUrl =
+  "https://github.com/JSONbored/nightward/blob/main/docs/privacy-model.md";
+
+export default function Command() {
+  const runtime = normalizePreferences(getPreferenceValues());
+  const { data, error, isLoading, revalidate } = usePromise(() =>
+    analysisReport(runtime),
+  );
+
+  if (error) {
+    return (
+      <Detail
+        markdown={`# Nightward Analysis\n\n${error.message}`}
+        actions={<AnalysisActions onRefresh={revalidate} />}
+      />
+    );
+  }
+
+  if (!data) {
+    return (
+      <List
+        isLoading={isLoading}
+        searchBarPlaceholder="Loading Nightward analysis..."
+      />
+    );
+  }
+
+  return (
+    <List
+      isLoading={isLoading}
+      searchBarPlaceholder="Search analysis signals..."
+      isShowingDetail
+    >
+      <List.Section title="Summary">
+        <List.Item
+          title="Analysis Summary"
+          subtitle={`${data.summary.total_signals} signals - ${data.summary.provider_warnings} provider warnings`}
+          icon={{
+            source: Icon.MagnifyingGlass,
+            tintColor: severityColor(data.summary.highest_severity || "info"),
+          }}
+          detail={<AnalysisDetail report={data} />}
+          actions={<AnalysisActions onRefresh={revalidate} />}
+        />
+      </List.Section>
+      <List.Section title="Signals">
+        {sortedSignals(data.signals).map((signal) => (
+          <SignalItem key={signal.id} signal={signal} onRefresh={revalidate} />
+        ))}
+      </List.Section>
+    </List>
+  );
+}
+
+function SignalItem({
+  signal,
+  onRefresh,
+}: {
+  signal: AnalysisSignal;
+  onRefresh: () => void;
+}) {
+  return (
+    <List.Item
+      title={signal.rule}
+      subtitle={signal.message}
+      icon={{ source: Icon.Warning, tintColor: severityColor(signal.severity) }}
+      accessories={[
+        { text: signal.severity },
+        { text: signal.confidence },
+        { text: signal.provider },
+      ]}
+      detail={<List.Item.Detail markdown={signalMarkdown(signal)} />}
+      actions={
+        <ActionPanel>
+          <Action.CopyToClipboard title="Copy Signal ID" content={signal.id} />
+          <Action.CopyToClipboard
+            title="Copy Path"
+            content={signal.path ?? ""}
+            shortcut={{ modifiers: ["cmd"], key: "." }}
+          />
+          <Action.OpenInBrowser title="Open Privacy Model" url={docsUrl} />
+          <Action
+            title="Refresh"
+            icon={Icon.ArrowClockwise}
+            onAction={onRefresh}
+          />
+        </ActionPanel>
+      }
+    />
+  );
+}
+
+function AnalysisDetail({ report }: { report: AnalysisReport }) {
+  return (
+    <List.Item.Detail
+      markdown={analysisMarkdown(report)}
+      metadata={
+        <List.Item.Detail.Metadata>
+          <List.Item.Detail.Metadata.Label
+            title="Signals"
+            text={String(report.summary.total_signals)}
+          />
+          <List.Item.Detail.Metadata.Label
+            title="Subjects"
+            text={String(report.summary.total_subjects)}
+          />
+          <List.Item.Detail.Metadata.Label
+            title="Provider Warnings"
+            text={String(report.summary.provider_warnings)}
+          />
+          <List.Item.Detail.Metadata.TagList title="Mode">
+            <List.Item.Detail.Metadata.TagList.Item
+              text={report.mode}
+              color={Color.Blue}
+            />
+          </List.Item.Detail.Metadata.TagList>
+        </List.Item.Detail.Metadata>
+      }
+    />
+  );
+}
+
+function AnalysisActions({ onRefresh }: { onRefresh: () => void }) {
+  return (
+    <ActionPanel>
+      <Action title="Refresh" icon={Icon.ArrowClockwise} onAction={onRefresh} />
+      <Action.OpenInBrowser title="Open Privacy Model" url={docsUrl} />
+    </ActionPanel>
+  );
+}

--- a/integrations/raycast/src/dashboard.tsx
+++ b/integrations/raycast/src/dashboard.tsx
@@ -18,6 +18,7 @@ import {
   sortedFindings,
 } from "./format";
 import {
+  analysisReport,
   doctor,
   fixPlan,
   normalizePreferences,
@@ -26,6 +27,7 @@ import {
 } from "./nightward";
 import type {
   Classification,
+  AnalysisReport,
   DoctorReport,
   FixPlan,
   ScanReport,
@@ -37,17 +39,19 @@ type DashboardData = {
   report: ScanReport;
   doctor: DoctorReport;
   fixPlan: FixPlan;
+  analysis: AnalysisReport;
 };
 
 export default function Command() {
   const runtime = normalizePreferences(getPreferenceValues());
   const { data, error, isLoading, revalidate } = usePromise(async () => {
-    const [report, doctorReport, plan] = await Promise.all([
+    const [report, doctorReport, plan, analysis] = await Promise.all([
       scan(runtime),
       doctor(runtime),
       fixPlan(runtime),
+      analysisReport(runtime),
     ]);
-    return { report, doctor: doctorReport, fixPlan: plan };
+    return { report, doctor: doctorReport, fixPlan: plan, analysis };
   });
 
   if (error) {
@@ -139,6 +143,30 @@ export default function Command() {
             />
           }
         />
+        <List.Item
+          title="Analysis"
+          subtitle={`${data.analysis.summary.total_signals} signals - ${data.analysis.summary.provider_warnings} provider warnings`}
+          icon={{
+            source: Icon.MagnifyingGlass,
+            tintColor: severityColor(
+              data.analysis.summary.highest_severity || "info",
+            ),
+          }}
+          accessories={[
+            { text: data.analysis.summary.highest_severity || "info" },
+          ]}
+          detail={
+            <List.Item.Detail
+              markdown={`# Analysis\n\nSignals: \`${data.analysis.summary.total_signals}\`\n\nProvider warnings: \`${data.analysis.summary.provider_warnings}\`\n\nOffline analysis does not claim a server or package is safe.`}
+            />
+          }
+          actions={
+            <DashboardActions
+              onRefresh={revalidate}
+              reportDir={data.doctor.schedule.report_dir}
+            />
+          }
+        />
       </List.Section>
 
       <List.Section title="Classifications">
@@ -221,6 +249,10 @@ function DashboardDetail({ data }: { data: DashboardData }) {
           <List.Item.Detail.Metadata.Label
             title="Fix Plan"
             text={`${data.fixPlan.summary.total} total`}
+          />
+          <List.Item.Detail.Metadata.Label
+            title="Analysis"
+            text={`${data.analysis.summary.total_signals} signals`}
           />
           <List.Item.Detail.Metadata.Label
             title="Report Directory"

--- a/integrations/raycast/src/dashboard.tsx
+++ b/integrations/raycast/src/dashboard.tsx
@@ -295,7 +295,7 @@ function classificationRows(
   return order
     .map((classification): [Classification, number] => [
       classification,
-      report.summary.by_classification[classification] ?? 0,
+      report.summary.items_by_classification[classification] ?? 0,
     ])
     .filter(([, count]) => count > 0);
 }

--- a/integrations/raycast/src/explain-signal.tsx
+++ b/integrations/raycast/src/explain-signal.tsx
@@ -1,0 +1,53 @@
+import {
+  Action,
+  ActionPanel,
+  Detail,
+  Icon,
+  getPreferenceValues,
+} from "@raycast/api";
+import { usePromise } from "@raycast/utils";
+import { signalMarkdown } from "./format";
+import { explainSignal, normalizePreferences } from "./nightward";
+
+type Arguments = {
+  findingId: string;
+};
+
+export default function Command(props: { arguments: Arguments }) {
+  const runtime = normalizePreferences(getPreferenceValues());
+  const findingId = props.arguments.findingId.trim();
+  const { data, error, isLoading, revalidate } = usePromise(
+    (id: string) => explainSignal(id, runtime),
+    [findingId],
+  );
+  const signal = data?.signals[0];
+
+  if (error) {
+    return <Detail markdown={`# Nightward Signal\n\n${error.message}`} />;
+  }
+  return (
+    <Detail
+      isLoading={isLoading}
+      markdown={
+        signal
+          ? signalMarkdown(signal)
+          : "# Nightward Signal\n\nNo analysis signal matched that finding."
+      }
+      actions={
+        <ActionPanel>
+          {signal ? (
+            <Action.CopyToClipboard
+              title="Copy Signal ID"
+              content={signal.id}
+            />
+          ) : null}
+          <Action
+            title="Refresh"
+            icon={Icon.ArrowClockwise}
+            onAction={revalidate}
+          />
+        </ActionPanel>
+      }
+    />
+  );
+}

--- a/integrations/raycast/src/export-analysis.ts
+++ b/integrations/raycast/src/export-analysis.ts
@@ -1,0 +1,21 @@
+import { Clipboard, Toast, getPreferenceValues, showToast } from "@raycast/api";
+import { exportAnalysisMarkdown, normalizePreferences } from "./nightward";
+
+export default async function Command() {
+  const runtime = normalizePreferences(getPreferenceValues());
+  try {
+    const markdown = await exportAnalysisMarkdown(runtime);
+    await Clipboard.copy(markdown);
+    await showToast({
+      style: Toast.Style.Success,
+      title: "Copied Nightward analysis",
+      message: "Redacted analysis report copied to clipboard.",
+    });
+  } catch (error) {
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "Analysis export failed",
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+}

--- a/integrations/raycast/src/format.ts
+++ b/integrations/raycast/src/format.ts
@@ -9,8 +9,7 @@ import type {
 
 const secretAssignmentPattern =
   /((?:token|secret|password|passwd|api[_-]?key|auth|credential|private[_-]?key)[\w.-]*\s*[:=]\s*)(["']?)[^"',\s}]+/gi;
-const longSecretLikePattern =
-  /\b(?:sk-[A-Za-z0-9_-]{12,}|[A-Za-z0-9_./+=-]{32,})\b/g;
+const longSecretLikePattern = /\bsk-[A-Za-z0-9_-]{12,}\b/g;
 
 const riskRank: Record<RiskLevel, number> = {
   info: 0,

--- a/integrations/raycast/src/format.ts
+++ b/integrations/raycast/src/format.ts
@@ -162,6 +162,8 @@ export function dashboardMarkdown(
     `Items: \`${report.summary.total_items}\``,
     `Findings: \`${report.summary.total_findings}\``,
     `Max severity: \`${max}\``,
+    `Critical findings: \`${report.summary.findings_by_severity.critical ?? 0}\``,
+    `High findings: \`${report.summary.findings_by_severity.high ?? 0}\``,
     "",
     "## Schedule",
     `Installed: \`${doctor.schedule?.installed ? "yes" : "no"}\``,

--- a/integrations/raycast/src/format.ts
+++ b/integrations/raycast/src/format.ts
@@ -1,5 +1,7 @@
 import type {
   AdapterStatus,
+  AnalysisReport,
+  AnalysisSignal,
   Classification,
   Finding,
   FixPlan,
@@ -136,6 +138,71 @@ export function findingMarkdown(finding: Finding): string {
     lines.push("", "## Why This Matters", redactText(finding.why_this_matters));
   }
 
+  return lines.join("\n");
+}
+
+export function sortedSignals(signals: AnalysisSignal[]): AnalysisSignal[] {
+  return [...signals].sort((a, b) => {
+    const riskDelta = riskRank[b.severity] - riskRank[a.severity];
+    if (riskDelta !== 0) return riskDelta;
+    if (a.provider !== b.provider) return a.provider.localeCompare(b.provider);
+    if (a.rule !== b.rule) return a.rule.localeCompare(b.rule);
+    return a.id.localeCompare(b.id);
+  });
+}
+
+export function signalMarkdown(signal: AnalysisSignal): string {
+  return [
+    `# ${escapeMarkdown(signal.rule)}`,
+    "",
+    redactText(signal.message),
+    "",
+    "## Evidence",
+    signal.evidence
+      ? `\`${escapeCode(redactText(signal.evidence))}\``
+      : "No redacted evidence was emitted for this signal.",
+    "",
+    "## Recommended Action",
+    redactText(signal.recommended_action),
+    "",
+    "## Metadata",
+    `Provider: \`${signal.provider}\``,
+    `Category: \`${signal.category}\``,
+    `Severity: \`${signal.severity}\``,
+    `Confidence: \`${signal.confidence}\``,
+    signal.path ? `Path: \`${escapeCode(signal.path)}\`` : "",
+    signal.why_this_matters ? "" : "",
+    signal.why_this_matters ? "## Why This Matters" : "",
+    signal.why_this_matters ? redactText(signal.why_this_matters) : "",
+  ]
+    .filter((line) => line !== "")
+    .join("\n");
+}
+
+export function analysisMarkdown(report: AnalysisReport): string {
+  const lines = [
+    "# Nightward Analysis",
+    "",
+    `Generated: \`${report.generated_at}\``,
+    `Mode: \`${report.mode}\``,
+    report.workspace ? `Workspace: \`${report.workspace}\`` : "",
+    "",
+    "## Summary",
+    `Signals: \`${report.summary.total_signals}\``,
+    `Subjects: \`${report.summary.total_subjects}\``,
+    `Highest severity: \`${report.summary.highest_severity || "info"}\``,
+    `Provider warnings: \`${report.summary.provider_warnings}\``,
+    "",
+    "Nightward analysis is offline by default and does not claim a package or server is safe.",
+  ].filter(Boolean);
+  if (report.signals.length > 0) {
+    lines.push("", "## Top Signals");
+    for (const signal of sortedSignals(report.signals).slice(0, 8)) {
+      lines.push(
+        `- \`${signal.severity}\` ${signal.rule}: ${redactText(signal.message)}`,
+      );
+    }
+  }
   return lines.join("\n");
 }
 

--- a/integrations/raycast/src/nightward.ts
+++ b/integrations/raycast/src/nightward.ts
@@ -2,7 +2,14 @@ import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type { DoctorReport, Finding, FixPlan, ScanReport } from "./types";
+import type {
+  AnalysisReport,
+  DoctorReport,
+  Finding,
+  FixPlan,
+  ProviderStatus,
+  ScanReport,
+} from "./types";
 import { redactText } from "./format";
 
 type ExecFileOptions = {
@@ -81,6 +88,65 @@ export async function explainFinding(
 
 export async function fixPlan(options: RuntimeOptions): Promise<FixPlan> {
   return runNightwardJSON<FixPlan>(["fix", "plan", "--all", "--json"], options);
+}
+
+export async function analysisReport(
+  options: RuntimeOptions,
+): Promise<AnalysisReport> {
+  return runNightwardJSON<AnalysisReport>(
+    ["analyze", "--all", "--json"],
+    options,
+  );
+}
+
+export async function providersDoctor(
+  options: RuntimeOptions,
+): Promise<ProviderStatus[]> {
+  return runNightwardJSON<ProviderStatus[]>(
+    ["providers", "doctor", "--json"],
+    options,
+  );
+}
+
+export async function explainSignal(
+  findingId: string,
+  options: RuntimeOptions,
+): Promise<AnalysisReport> {
+  return runNightwardJSON<AnalysisReport>(
+    ["analyze", "finding", findingId, "--json"],
+    options,
+  );
+}
+
+export async function exportAnalysisMarkdown(
+  options: RuntimeOptions,
+): Promise<string> {
+  const report = await analysisReport(options);
+  return [
+    "# Nightward Analysis",
+    "",
+    `Generated: \`${report.generated_at}\``,
+    `Mode: \`${report.mode}\``,
+    `Signals: \`${report.summary.total_signals}\``,
+    `Highest severity: \`${report.summary.highest_severity || "info"}\``,
+    "",
+    ...report.signals.map((signal) =>
+      [
+        `## ${signal.rule}`,
+        "",
+        `- Severity: \`${signal.severity}\``,
+        `- Confidence: \`${signal.confidence}\``,
+        `- Provider: \`${signal.provider}\``,
+        signal.path ? `- Path: \`${signal.path}\`` : "",
+        "",
+        redactText(signal.message),
+        "",
+        `Recommended action: ${redactText(signal.recommended_action)}`,
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    ),
+  ].join("\n");
 }
 
 export async function exportFixPlanMarkdown(

--- a/integrations/raycast/src/provider-doctor.tsx
+++ b/integrations/raycast/src/provider-doctor.tsx
@@ -1,0 +1,117 @@
+import {
+  Action,
+  ActionPanel,
+  Color,
+  Icon,
+  List,
+  getPreferenceValues,
+} from "@raycast/api";
+import { usePromise } from "@raycast/utils";
+import { normalizePreferences, providersDoctor } from "./nightward";
+import type { ProviderStatus } from "./types";
+
+export default function Command() {
+  const runtime = normalizePreferences(getPreferenceValues());
+  const { data, error, isLoading, revalidate } = usePromise(() =>
+    providersDoctor(runtime),
+  );
+
+  if (error) {
+    return (
+      <List isLoading={false}>
+        <List.EmptyView
+          title="Nightward provider doctor failed"
+          description={error.message}
+        />
+      </List>
+    );
+  }
+
+  return (
+    <List
+      isLoading={isLoading}
+      searchBarPlaceholder="Search Nightward providers..."
+      isShowingDetail
+    >
+      {(data ?? []).map((provider) => (
+        <ProviderItem
+          key={provider.name}
+          provider={provider}
+          onRefresh={revalidate}
+        />
+      ))}
+    </List>
+  );
+}
+
+function ProviderItem({
+  provider,
+  onRefresh,
+}: {
+  provider: ProviderStatus;
+  onRefresh: () => void;
+}) {
+  return (
+    <List.Item
+      title={provider.name}
+      subtitle={`${provider.status} - ${provider.capabilities}`}
+      icon={{
+        source: providerIcon(provider),
+        tintColor: providerColor(provider),
+      }}
+      accessories={[
+        { text: provider.enabled ? "enabled" : "disabled" },
+        { text: provider.online ? "online-capable" : "offline" },
+      ]}
+      detail={
+        <List.Item.Detail
+          markdown={[
+            `# ${provider.name}`,
+            "",
+            `Status: \`${provider.status}\``,
+            `Available: \`${String(provider.available)}\``,
+            `Enabled: \`${String(provider.enabled)}\``,
+            `Privacy: ${provider.privacy}`,
+            "",
+            provider.detail ? `Detail: \`${provider.detail}\`` : "",
+          ]
+            .filter(Boolean)
+            .join("\n")}
+        />
+      }
+      actions={
+        <ActionPanel>
+          <Action.CopyToClipboard
+            title="Copy Provider Name"
+            content={provider.name}
+          />
+          {provider.command ? (
+            <Action.CopyToClipboard
+              title="Copy Command Name"
+              content={provider.command}
+            />
+          ) : null}
+          <Action
+            title="Refresh"
+            icon={Icon.ArrowClockwise}
+            onAction={onRefresh}
+          />
+        </ActionPanel>
+      }
+    />
+  );
+}
+
+function providerIcon(provider: ProviderStatus): Icon {
+  if (provider.status === "ready") return Icon.CheckCircle;
+  if (provider.status === "blocked") return Icon.Lock;
+  if (provider.available) return Icon.Circle;
+  return Icon.XMarkCircle;
+}
+
+function providerColor(provider: ProviderStatus): Color {
+  if (provider.status === "ready") return Color.Green;
+  if (provider.status === "blocked") return Color.Yellow;
+  if (provider.available) return Color.Blue;
+  return Color.Red;
+}

--- a/integrations/raycast/src/types.ts
+++ b/integrations/raycast/src/types.ts
@@ -19,9 +19,12 @@ export type FixKind =
 export type Summary = {
   total_items: number;
   total_findings: number;
-  by_classification: Partial<Record<Classification, number>>;
-  by_risk: Partial<Record<RiskLevel, number>>;
-  tools: Record<string, number>;
+  items_by_classification: Partial<Record<Classification, number>>;
+  items_by_risk: Partial<Record<RiskLevel, number>>;
+  items_by_tool: Record<string, number>;
+  findings_by_severity: Partial<Record<RiskLevel, number>>;
+  findings_by_rule: Record<string, number>;
+  findings_by_tool: Record<string, number>;
 };
 
 export type InventoryItem = {

--- a/integrations/raycast/src/types.ts
+++ b/integrations/raycast/src/types.ts
@@ -76,10 +76,80 @@ export type ScanReport = {
   generated_at: string;
   hostname: string;
   home: string;
+  workspace?: string;
+  scan_mode?: string;
   summary: Summary;
   items: InventoryItem[];
   findings: Finding[];
   adapters: AdapterStatus[];
+};
+
+export type SignalCategory =
+  | "supply-chain"
+  | "secrets-exposure"
+  | "filesystem-scope"
+  | "network-exposure"
+  | "execution-risk"
+  | "machine-locality"
+  | "app-state"
+  | "unknown";
+
+export type AnalysisSignal = {
+  id: string;
+  provider: string;
+  rule: string;
+  category: SignalCategory;
+  subject_id: string;
+  subject_type: "finding" | "item" | "package";
+  path?: string;
+  severity: RiskLevel;
+  confidence: string;
+  message: string;
+  evidence?: string;
+  recommended_action: string;
+  why_this_matters?: string;
+};
+
+export type ProviderStatus = {
+  name: string;
+  kind: string;
+  command?: string;
+  online: boolean;
+  default: boolean;
+  privacy: string;
+  capabilities: string;
+  enabled: boolean;
+  available: boolean;
+  status: string;
+  detail?: string;
+};
+
+export type AnalysisReport = {
+  generated_at: string;
+  mode: string;
+  workspace?: string;
+  summary: {
+    total_subjects: number;
+    total_signals: number;
+    signals_by_severity: Partial<Record<RiskLevel, number>>;
+    signals_by_category: Partial<Record<SignalCategory, number>>;
+    signals_by_provider: Record<string, number>;
+    highest_severity: RiskLevel;
+    provider_warnings: number;
+    no_known_risk_signals: boolean;
+  };
+  providers: ProviderStatus[];
+  subjects: Array<{
+    id: string;
+    type: "finding" | "item" | "package";
+    name: string;
+    tool?: string;
+    path?: string;
+    rule?: string;
+    package?: string;
+    evidence?: string;
+  }>;
+  signals: AnalysisSignal[];
 };
 
 export type DoctorCheck = {

--- a/integrations/raycast/test/format.test.ts
+++ b/integrations/raycast/test/format.test.ts
@@ -1,12 +1,15 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  analysisMarkdown,
   findingMarkdown,
   maxSeverity,
   redactText,
+  signalMarkdown,
   sortedFindings,
+  sortedSignals,
 } from "../src/format";
-import type { Finding } from "../src/types";
+import type { AnalysisReport, AnalysisSignal, Finding } from "../src/types";
 
 test("redacts obvious secret assignments and long token-like values", () => {
   const keyName = "API_" + "KEY";
@@ -70,6 +73,45 @@ test("findings sort by severity then stable identity", () => {
   );
 });
 
+test("analysis markdown redacts signal evidence", () => {
+  const keyName = "API_" + "KEY";
+  const token = "sk-" + "1234567890abcdef";
+  const signal: AnalysisSignal = {
+    id: "signal-a",
+    provider: "nightward",
+    rule: "nightward/mcp_secret_env",
+    category: "secrets-exposure",
+    subject_id: "finding-a",
+    subject_type: "finding",
+    severity: "critical",
+    confidence: "high",
+    message: `${keyName}=${token}`,
+    evidence: "env_key=API_KEY",
+    recommended_action: `Remove ${keyName}=${token}.`,
+  };
+  const report: AnalysisReport = {
+    generated_at: "2026-04-30T00:00:00Z",
+    mode: "home",
+    summary: {
+      total_subjects: 1,
+      total_signals: 1,
+      signals_by_severity: { critical: 1 },
+      signals_by_category: { "secrets-exposure": 1 },
+      signals_by_provider: { nightward: 1 },
+      highest_severity: "critical",
+      provider_warnings: 0,
+      no_known_risk_signals: false,
+    },
+    providers: [],
+    subjects: [],
+    signals: [signal],
+  };
+
+  assert.equal(sortedSignals([baseSignal("b", "low"), signal])[0]?.id, "signal-a");
+  assert.doesNotMatch(signalMarkdown(signal), /1234567890abcdef/);
+  assert.doesNotMatch(analysisMarkdown(report), /1234567890abcdef/);
+});
+
 function baseFinding(
   id: string,
   severity: Finding["severity"],
@@ -85,5 +127,20 @@ function baseFinding(
     recommended_action: "Review manually.",
     fix_available: false,
     requires_review: true,
+  };
+}
+
+function baseSignal(id: string, severity: AnalysisSignal["severity"]): AnalysisSignal {
+  return {
+    id,
+    provider: "nightward",
+    rule: "nightward/review",
+    category: "execution-risk",
+    subject_id: id,
+    subject_type: "finding",
+    severity,
+    confidence: "medium",
+    message: "Review signal",
+    recommended_action: "Review manually.",
   };
 }

--- a/integrations/raycast/test/format.test.ts
+++ b/integrations/raycast/test/format.test.ts
@@ -1,15 +1,28 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { findingMarkdown, maxSeverity, redactText, sortedFindings } from "../src/format";
+import {
+  findingMarkdown,
+  maxSeverity,
+  redactText,
+  sortedFindings,
+} from "../src/format";
 import type { Finding } from "../src/types";
 
 test("redacts obvious secret assignments and long token-like values", () => {
   const keyName = "API_" + "KEY";
   const token = "sk-" + "1234567890abcdef";
   const longValue = "abcdefghijklmno" + "pqrstuvwxyz123456";
-  const output = redactText(`${keyName}=${token} secret: ${longValue}`);
+  const path =
+    "/Users/example/Library/Application Support/Claude/claude_desktop_config.json";
+  const output = redactText(
+    `${keyName}=${token} secret: ${longValue} path: ${path}`,
+  );
   assert.match(output, /API_KEY=\[redacted\]/);
   assert.match(output, /secret: \[redacted\]/);
+  assert.match(
+    output,
+    /Library\/Application Support\/Claude\/claude_desktop_config\.json/,
+  );
   assert.doesNotMatch(output, /1234567890abcdef/);
   assert.doesNotMatch(output, /abcdefghijklmnopqrstuvwxyz123456/);
 });
@@ -57,7 +70,11 @@ test("findings sort by severity then stable identity", () => {
   );
 });
 
-function baseFinding(id: string, severity: Finding["severity"], tool: string): Finding {
+function baseFinding(
+  id: string,
+  severity: Finding["severity"],
+  tool: string,
+): Finding {
   return {
     id,
     tool,

--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -1,7 +1,7 @@
 package analysis
 
 import (
-	"crypto/sha1"
+	"crypto/sha1" // #nosec G505 -- used only for short deterministic non-security IDs.
 	"encoding/hex"
 	"fmt"
 	"os/exec"
@@ -422,7 +422,7 @@ func selectedProviders(with []string) map[string]bool {
 }
 
 func stableID(parts ...string) string {
-	hash := sha1.Sum([]byte(strings.Join(parts, "\x00")))
+	hash := sha1.Sum([]byte(strings.Join(parts, "\x00"))) // #nosec G401 -- stable label only, not a cryptographic control.
 	return hex.EncodeToString(hash[:])[:12]
 }
 

--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -1,0 +1,464 @@
+package analysis
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jsonbored/nightward/internal/inventory"
+)
+
+type SubjectType string
+
+const (
+	SubjectFinding SubjectType = "finding"
+	SubjectItem    SubjectType = "item"
+	SubjectPackage SubjectType = "package"
+)
+
+type SignalCategory string
+
+const (
+	CategorySupplyChain SignalCategory = "supply-chain"
+	CategorySecrets     SignalCategory = "secrets-exposure"
+	CategoryFilesystem  SignalCategory = "filesystem-scope"
+	CategoryNetwork     SignalCategory = "network-exposure"
+	CategoryExecution   SignalCategory = "execution-risk"
+	CategoryLocality    SignalCategory = "machine-locality"
+	CategoryAppState    SignalCategory = "app-state"
+	CategoryUnknown     SignalCategory = "unknown"
+)
+
+type Options struct {
+	Mode      string
+	Workspace string
+	With      []string
+	Online    bool
+	Package   string
+	FindingID string
+}
+
+type Report struct {
+	GeneratedAt time.Time        `json:"generated_at"`
+	Mode        string           `json:"mode"`
+	Workspace   string           `json:"workspace,omitempty"`
+	Summary     Summary          `json:"summary"`
+	Providers   []ProviderStatus `json:"providers"`
+	Subjects    []Subject        `json:"subjects"`
+	Signals     []Signal         `json:"signals"`
+}
+
+type Summary struct {
+	TotalSubjects      int                         `json:"total_subjects"`
+	TotalSignals       int                         `json:"total_signals"`
+	SignalsBySeverity  map[inventory.RiskLevel]int `json:"signals_by_severity"`
+	SignalsByCategory  map[SignalCategory]int      `json:"signals_by_category"`
+	SignalsByProvider  map[string]int              `json:"signals_by_provider"`
+	HighestSeverity    inventory.RiskLevel         `json:"highest_severity"`
+	ProviderWarnings   int                         `json:"provider_warnings"`
+	NoKnownRiskSignals bool                        `json:"no_known_risk_signals"`
+}
+
+type Subject struct {
+	ID       string      `json:"id"`
+	Type     SubjectType `json:"type"`
+	Name     string      `json:"name"`
+	Tool     string      `json:"tool,omitempty"`
+	Path     string      `json:"path,omitempty"`
+	Rule     string      `json:"rule,omitempty"`
+	Package  string      `json:"package,omitempty"`
+	Evidence string      `json:"evidence,omitempty"`
+}
+
+type Signal struct {
+	ID             string              `json:"id"`
+	Provider       string              `json:"provider"`
+	Rule           string              `json:"rule"`
+	Category       SignalCategory      `json:"category"`
+	SubjectID      string              `json:"subject_id"`
+	SubjectType    SubjectType         `json:"subject_type"`
+	Path           string              `json:"path,omitempty"`
+	Severity       inventory.RiskLevel `json:"severity"`
+	Confidence     string              `json:"confidence"`
+	Message        string              `json:"message"`
+	Evidence       string              `json:"evidence,omitempty"`
+	Recommendation string              `json:"recommended_action"`
+	Why            string              `json:"why_this_matters,omitempty"`
+}
+
+type Provider struct {
+	Name         string `json:"name"`
+	Kind         string `json:"kind"`
+	Command      string `json:"command,omitempty"`
+	Online       bool   `json:"online"`
+	Default      bool   `json:"default"`
+	Privacy      string `json:"privacy"`
+	Capabilities string `json:"capabilities"`
+}
+
+type ProviderStatus struct {
+	Provider
+	Enabled   bool   `json:"enabled"`
+	Available bool   `json:"available"`
+	Status    string `json:"status"`
+	Detail    string `json:"detail,omitempty"`
+}
+
+func Run(report inventory.Report, options Options) Report {
+	if options.Mode == "" {
+		options.Mode = "home"
+	}
+	out := Report{
+		GeneratedAt: report.GeneratedAt,
+		Mode:        options.Mode,
+		Workspace:   options.Workspace,
+		Summary: Summary{
+			SignalsBySeverity: map[inventory.RiskLevel]int{},
+			SignalsByCategory: map[SignalCategory]int{},
+			SignalsByProvider: map[string]int{},
+		},
+		Providers: ProviderStatuses(options.With, options.Online),
+	}
+
+	if options.Package != "" {
+		subject := Subject{
+			ID:      stableID("package", options.Package),
+			Type:    SubjectPackage,
+			Name:    options.Package,
+			Package: options.Package,
+		}
+		out.Subjects = append(out.Subjects, subject)
+		out.Signals = append(out.Signals, Signal{
+			ID:             stableID("signal", "nightward", "package_review", options.Package),
+			Provider:       "nightward",
+			Rule:           "package_review",
+			Category:       CategorySupplyChain,
+			SubjectID:      subject.ID,
+			SubjectType:    subject.Type,
+			Severity:       inventory.RiskInfo,
+			Confidence:     "low",
+			Message:        "Package analysis is structural only without an explicit provider.",
+			Evidence:       "package=" + options.Package,
+			Recommendation: "Run with an explicit provider after reviewing provider privacy behavior.",
+			Why:            "Nightward avoids making safety claims about packages without registry or vulnerability evidence.",
+		})
+	}
+
+	for _, finding := range report.Findings {
+		if options.FindingID != "" && finding.ID != options.FindingID && !strings.HasPrefix(finding.ID, options.FindingID) {
+			continue
+		}
+		subject := Subject{
+			ID:       stableID("finding", finding.ID),
+			Type:     SubjectFinding,
+			Name:     finding.ID,
+			Tool:     finding.Tool,
+			Path:     finding.Path,
+			Rule:     finding.Rule,
+			Evidence: finding.Evidence,
+		}
+		out.Subjects = append(out.Subjects, subject)
+		out.Signals = append(out.Signals, signalFromFinding(subject, finding))
+	}
+
+	if options.FindingID == "" && options.Package == "" {
+		for _, item := range report.Items {
+			if signal, ok := signalFromItem(item); ok {
+				subject := Subject{
+					ID:       stableID("item", item.ID),
+					Type:     SubjectItem,
+					Name:     item.ID,
+					Tool:     item.Tool,
+					Path:     item.Path,
+					Evidence: string(item.Classification),
+				}
+				out.Subjects = append(out.Subjects, subject)
+				signal.SubjectID = subject.ID
+				out.Signals = append(out.Signals, signal)
+			}
+		}
+	}
+
+	sort.Slice(out.Subjects, func(i, j int) bool {
+		if out.Subjects[i].Type == out.Subjects[j].Type {
+			return out.Subjects[i].Name < out.Subjects[j].Name
+		}
+		return out.Subjects[i].Type < out.Subjects[j].Type
+	})
+	sort.Slice(out.Signals, func(i, j int) bool {
+		if out.Signals[i].Severity == out.Signals[j].Severity {
+			return out.Signals[i].ID < out.Signals[j].ID
+		}
+		return riskRank(out.Signals[i].Severity) > riskRank(out.Signals[j].Severity)
+	})
+	finalize(&out)
+	return out
+}
+
+func Explain(report Report, idOrPrefix string) (Signal, bool) {
+	for _, signal := range report.Signals {
+		if signal.ID == idOrPrefix {
+			return signal, true
+		}
+	}
+	var matched []Signal
+	for _, signal := range report.Signals {
+		if strings.HasPrefix(signal.ID, idOrPrefix) {
+			matched = append(matched, signal)
+		}
+	}
+	if len(matched) == 1 {
+		return matched[0], true
+	}
+	return Signal{}, false
+}
+
+func Providers() []Provider {
+	return []Provider{
+		{Name: "nightward", Kind: "built-in", Default: true, Privacy: "offline; reads only the selected HOME or workspace", Capabilities: "MCP, dotfiles, secret-path, filesystem, and local-endpoint heuristics"},
+		{Name: "gitleaks", Kind: "local-command", Command: "gitleaks", Privacy: "local command; scans selected files when explicitly run", Capabilities: "secret pattern scanning"},
+		{Name: "trufflehog", Kind: "local-command", Command: "trufflehog", Privacy: "local command; scans selected files when explicitly run", Capabilities: "secret pattern scanning with verification disabled by default"},
+		{Name: "semgrep", Kind: "local-command", Command: "semgrep", Privacy: "local command; rule packs may require network if user config chooses that", Capabilities: "static analysis and malicious dependency rules"},
+		{Name: "trivy", Kind: "local-command", Command: "trivy", Online: true, Privacy: "network-capable; vulnerability database updates may contact upstream services", Capabilities: "filesystem, dependency, IaC, and secret scanning"},
+		{Name: "osv-scanner", Kind: "local-command", Command: "osv-scanner", Online: true, Privacy: "network-capable; queries vulnerability data for dependency manifests", Capabilities: "open source vulnerability matching"},
+		{Name: "socket", Kind: "local-command", Command: "socket", Online: true, Privacy: "network-capable; may send package metadata to Socket services", Capabilities: "supply-chain risk and malicious package signals"},
+	}
+}
+
+func ProviderStatuses(with []string, online bool) []ProviderStatus {
+	selected := selectedProviders(with)
+	out := make([]ProviderStatus, 0, len(Providers()))
+	known := map[string]bool{}
+	for _, provider := range Providers() {
+		known[provider.Name] = true
+		enabled := provider.Default || selected["all"] || selected[provider.Name]
+		status := ProviderStatus{Provider: provider, Enabled: enabled}
+		if provider.Kind == "built-in" {
+			status.Available = true
+			status.Status = "ready"
+			status.Detail = "built-in offline heuristics are enabled by default"
+			out = append(out, status)
+			continue
+		}
+		if provider.Command != "" {
+			if path, err := exec.LookPath(provider.Command); err == nil {
+				status.Available = true
+				status.Detail = path
+			} else {
+				status.Detail = "command not found on PATH"
+			}
+		}
+		switch {
+		case !enabled:
+			status.Status = "available"
+			if !status.Available {
+				status.Status = "missing"
+			}
+		case provider.Online && !online:
+			status.Status = "blocked"
+			status.Detail = strings.TrimSpace(status.Detail + "; requires --online before Nightward will use it")
+		case !status.Available:
+			status.Status = "missing"
+		default:
+			status.Status = "ready"
+			status.Detail = strings.TrimSpace(status.Detail + "; available for explicit provider runs")
+		}
+		out = append(out, status)
+	}
+	if !selected["all"] {
+		var unknown []string
+		for name := range selected {
+			if !known[name] {
+				unknown = append(unknown, name)
+			}
+		}
+		sort.Strings(unknown)
+		for _, name := range unknown {
+			out = append(out, ProviderStatus{
+				Provider: Provider{
+					Name:    name,
+					Kind:    "unknown",
+					Privacy: "unknown provider; Nightward did not run anything",
+				},
+				Enabled: true,
+				Status:  "unknown",
+				Detail:  "provider is not recognized by this Nightward version",
+			})
+		}
+	}
+	return out
+}
+
+func signalFromFinding(subject Subject, finding inventory.Finding) Signal {
+	category := categoryForRule(finding.Rule)
+	confidence := finding.Confidence
+	if confidence == "" {
+		confidence = "medium"
+	}
+	return Signal{
+		ID:             stableID("signal", "nightward", finding.Rule, finding.ID),
+		Provider:       "nightward",
+		Rule:           "nightward/" + finding.Rule,
+		Category:       category,
+		SubjectID:      subject.ID,
+		SubjectType:    subject.Type,
+		Path:           finding.Path,
+		Severity:       finding.Severity,
+		Confidence:     confidence,
+		Message:        finding.Message,
+		Evidence:       finding.Evidence,
+		Recommendation: finding.Recommendation,
+		Why:            finding.Why,
+	}
+}
+
+func signalFromItem(item inventory.Item) (Signal, bool) {
+	switch item.Classification {
+	case inventory.SecretAuth:
+		return Signal{
+			ID:             stableID("signal", "nightward", "secret_auth_path", item.ID),
+			Provider:       "nightward",
+			Rule:           "nightward/secret_auth_path",
+			Category:       CategorySecrets,
+			SubjectType:    SubjectItem,
+			Path:           item.Path,
+			Severity:       inventory.RiskCritical,
+			Confidence:     "high",
+			Message:        "Secret or auth path is present in the scan scope.",
+			Evidence:       "classification=secret-auth path=" + item.Path,
+			Recommendation: "Exclude this path from portable dotfiles and backups.",
+			Why:            "Credential-bearing files should remain in a password manager, keychain, or machine-local store.",
+		}, true
+	case inventory.MachineLocal:
+		return Signal{
+			ID:             stableID("signal", "nightward", "machine_local_path", item.ID),
+			Provider:       "nightward",
+			Rule:           "nightward/machine_local_path",
+			Category:       CategoryLocality,
+			SubjectType:    SubjectItem,
+			Path:           item.Path,
+			Severity:       inventory.RiskMedium,
+			Confidence:     "medium",
+			Message:        "Machine-local path is present in the scan scope.",
+			Evidence:       "classification=machine-local path=" + item.Path,
+			Recommendation: "Move machine-specific values to a local overlay or document them as setup prerequisites.",
+			Why:            "Portable repos should not silently depend on one machine's paths, sockets, identities, or services.",
+		}, true
+	case inventory.AppOwned:
+		return Signal{
+			ID:             stableID("signal", "nightward", "app_owned_state", item.ID),
+			Provider:       "nightward",
+			Rule:           "nightward/app_owned_state",
+			Category:       CategoryAppState,
+			SubjectType:    SubjectItem,
+			Path:           item.Path,
+			Severity:       inventory.RiskLow,
+			Confidence:     "medium",
+			Message:        "App-owned runtime state is present in the scan scope.",
+			Evidence:       "classification=app-owned path=" + item.Path,
+			Recommendation: "Prefer app-supported export formats over syncing raw runtime state.",
+			Why:            "Raw app databases and caches often contain local identifiers, private history, or binary state.",
+		}, true
+	default:
+		return Signal{}, false
+	}
+}
+
+func categoryForRule(rule string) SignalCategory {
+	switch rule {
+	case "mcp_unpinned_package":
+		return CategorySupplyChain
+	case "mcp_secret_env", "mcp_secret_header", "mcp_local_token_path":
+		return CategorySecrets
+	case "mcp_broad_filesystem":
+		return CategoryFilesystem
+	case "mcp_local_endpoint":
+		return CategoryNetwork
+	case "mcp_shell_command", "mcp_unknown_command":
+		return CategoryExecution
+	case "mcp_server_review":
+		return CategoryExecution
+	default:
+		return CategoryUnknown
+	}
+}
+
+func finalize(report *Report) {
+	report.Summary.TotalSubjects = len(report.Subjects)
+	report.Summary.TotalSignals = len(report.Signals)
+	report.Summary.HighestSeverity = inventory.RiskInfo
+	for _, signal := range report.Signals {
+		report.Summary.SignalsBySeverity[signal.Severity]++
+		report.Summary.SignalsByCategory[signal.Category]++
+		report.Summary.SignalsByProvider[signal.Provider]++
+		if riskRank(signal.Severity) > riskRank(report.Summary.HighestSeverity) {
+			report.Summary.HighestSeverity = signal.Severity
+		}
+	}
+	for _, provider := range report.Providers {
+		if provider.Enabled && (provider.Status == "missing" || provider.Status == "blocked" || provider.Status == "unknown") {
+			report.Summary.ProviderWarnings++
+		}
+	}
+	report.Summary.NoKnownRiskSignals = len(report.Signals) == 0
+}
+
+func selectedProviders(with []string) map[string]bool {
+	out := map[string]bool{}
+	for _, raw := range with {
+		for _, name := range strings.Split(raw, ",") {
+			name = strings.TrimSpace(strings.ToLower(name))
+			if name != "" {
+				out[name] = true
+			}
+		}
+	}
+	return out
+}
+
+func stableID(parts ...string) string {
+	hash := sha1.Sum([]byte(strings.Join(parts, "\x00")))
+	return hex.EncodeToString(hash[:])[:12]
+}
+
+func riskRank(risk inventory.RiskLevel) int {
+	switch risk {
+	case inventory.RiskCritical:
+		return 5
+	case inventory.RiskHigh:
+		return 4
+	case inventory.RiskMedium:
+		return 3
+	case inventory.RiskLow:
+		return 2
+	default:
+		return 1
+	}
+}
+
+func RelativeWorkspacePath(workspace, path string) string {
+	if workspace == "" || path == "" {
+		return path
+	}
+	rel, err := filepath.Rel(workspace, path)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return path
+	}
+	return rel
+}
+
+func HumanProviderSummary(status ProviderStatus) string {
+	availability := "missing"
+	if status.Available {
+		availability = "available"
+	}
+	if status.Enabled {
+		return fmt.Sprintf("%s enabled %s (%s)", status.Name, status.Status, availability)
+	}
+	return fmt.Sprintf("%s disabled %s", status.Name, availability)
+}

--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -1,0 +1,92 @@
+package analysis
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jsonbored/nightward/internal/inventory"
+)
+
+func TestAnalysisBuildsOfflineSignalsAndRedacts(t *testing.T) {
+	report := inventory.Report{
+		GeneratedAt: time.Date(2026, 4, 30, 7, 0, 0, 0, time.UTC),
+		Findings: []inventory.Finding{
+			{
+				ID:             "mcp_secret_env-111111111111",
+				Tool:           "Codex",
+				Path:           "/tmp/config.toml",
+				Severity:       inventory.RiskCritical,
+				Rule:           "mcp_secret_env",
+				Message:        "MCP server stores a sensitive environment key.",
+				Evidence:       "env_key=API_TOKEN",
+				Recommendation: "Keep secret values outside dotfiles.",
+				Why:            "Secrets should stay local.",
+				Confidence:     "high",
+			},
+		},
+		Items: []inventory.Item{
+			{
+				ID:             "secret-item",
+				Tool:           "Secrets",
+				Path:           "/tmp/workspace/.env",
+				Classification: inventory.SecretAuth,
+				Risk:           inventory.RiskCritical,
+			},
+		},
+	}
+
+	out := Run(report, Options{Mode: "workspace", Workspace: "/tmp/workspace"})
+	if out.Summary.TotalSignals != 2 {
+		t.Fatalf("expected two analysis signals, got %#v", out.Summary)
+	}
+	if out.Summary.SignalsByCategory[CategorySecrets] != 2 {
+		t.Fatalf("expected secret category signals, got %#v", out.Summary.SignalsByCategory)
+	}
+	data, err := json.Marshal(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "super-secret-value") {
+		t.Fatalf("analysis leaked a secret: %s", data)
+	}
+}
+
+func TestProviderDoctorHonorsOnlineGate(t *testing.T) {
+	statuses := ProviderStatuses([]string{"socket"}, false)
+	var found bool
+	for _, status := range statuses {
+		if status.Name == "socket" {
+			found = true
+			if status.Status != "blocked" {
+				t.Fatalf("expected socket to be blocked without --online, got %#v", status)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("missing socket provider")
+	}
+}
+
+func TestProviderDoctorFindsFakeLocalProvider(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gitleaks")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+
+	statuses := ProviderStatuses([]string{"gitleaks"}, false)
+	for _, status := range statuses {
+		if status.Name == "gitleaks" {
+			if !status.Available || status.Status != "ready" {
+				t.Fatalf("expected fake gitleaks to be ready, got %#v", status)
+			}
+			return
+		}
+	}
+	t.Fatal("missing gitleaks provider")
+}

--- a/internal/backupplan/plan.go
+++ b/internal/backupplan/plan.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/shadowbook/nightward/internal/inventory"
+	"github.com/jsonbored/nightward/internal/inventory"
 )
 
 type Action string

--- a/internal/backupplan/plan_test.go
+++ b/internal/backupplan/plan_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shadowbook/nightward/internal/inventory"
+	"github.com/jsonbored/nightward/internal/inventory"
 )
 
 func TestBuildClassifiesActions(t *testing.T) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -713,23 +713,29 @@ func commandCheck(name, detail string) Check {
 }
 
 func pathCheck(id, path string, required bool) Check {
-	info, err := os.Stat(path)
+	cleanPath := filepath.Clean(path)
+	info, err := os.Stat(cleanPath) // #nosec G703 -- doctor checks expected local filesystem prerequisites, not web/user content.
 	if err != nil {
 		status := "info"
 		if required {
 			status = "warn"
 		}
-		return Check{ID: id, Status: status, Message: "path missing", Detail: path}
+		return Check{ID: id, Status: status, Message: "path missing", Detail: cleanPath}
 	}
 	if !info.IsDir() {
-		return Check{ID: id, Status: "warn", Message: "path is not a directory", Detail: path}
+		return Check{ID: id, Status: "warn", Message: "path is not a directory", Detail: cleanPath}
 	}
-	return Check{ID: id, Status: "ok", Message: "path available", Detail: path}
+	return Check{ID: id, Status: "ok", Message: "path available", Detail: cleanPath}
 }
 
 func maybeWriteReport(report inventory.Report, output, outputDir string) error {
 	if outputDir != "" {
-		if err := os.MkdirAll(outputDir, 0755); err != nil {
+		var err error
+		outputDir, err = filepath.Abs(filepath.Clean(outputDir))
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(outputDir, 0700); err != nil {
 			return err
 		}
 		output = filepath.Join(outputDir, "nightward-scan-"+report.GeneratedAt.Format("20060102-150405Z")+".json")
@@ -737,7 +743,12 @@ func maybeWriteReport(report inventory.Report, output, outputDir string) error {
 	if output == "" {
 		return nil
 	}
-	if err := os.MkdirAll(filepath.Dir(output), 0755); err != nil {
+	var err error
+	output, err = filepath.Abs(filepath.Clean(output))
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(output), 0700); err != nil {
 		return err
 	}
 	data, err := json.MarshalIndent(report, "", "  ")
@@ -745,7 +756,7 @@ func maybeWriteReport(report inventory.Report, output, outputDir string) error {
 		return err
 	}
 	data = append(data, '\n')
-	return os.WriteFile(output, data, 0600)
+	return os.WriteFile(output, data, 0600) // #nosec G703 -- explicit user-selected report output path, normalized and private.
 }
 
 func printHelp(w io.Writer, commandName string) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -609,8 +609,17 @@ Short alias: nw
 
 func printScan(w io.Writer, report inventory.Report) {
 	fmt.Fprintf(w, "Nightward scan: %d items, %d findings\n", report.Summary.TotalItems, report.Summary.TotalFindings)
-	for class, count := range report.Summary.ByClassification {
+	fmt.Fprintln(w, "Items by classification:")
+	for class, count := range report.Summary.ItemsByClassification {
 		fmt.Fprintf(w, "  %-14s %d\n", class, count)
+	}
+	if len(report.Summary.FindingsBySeverity) > 0 {
+		fmt.Fprintln(w, "Findings by severity:")
+		for _, severity := range []inventory.RiskLevel{inventory.RiskCritical, inventory.RiskHigh, inventory.RiskMedium, inventory.RiskLow, inventory.RiskInfo} {
+			if count := report.Summary.FindingsBySeverity[severity]; count > 0 {
+				fmt.Fprintf(w, "  %-14s %d\n", severity, count)
+			}
+		}
 	}
 	if len(report.Findings) > 0 {
 		fmt.Fprintln(w, "\nTop findings:")

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -11,13 +11,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/shadowbook/nightward/internal/backupplan"
-	"github.com/shadowbook/nightward/internal/fixplan"
-	"github.com/shadowbook/nightward/internal/inventory"
-	"github.com/shadowbook/nightward/internal/policy"
-	"github.com/shadowbook/nightward/internal/schedule"
-	"github.com/shadowbook/nightward/internal/snapshot"
-	"github.com/shadowbook/nightward/internal/tui"
+	"github.com/jsonbored/nightward/internal/analysis"
+	"github.com/jsonbored/nightward/internal/backupplan"
+	"github.com/jsonbored/nightward/internal/fixplan"
+	"github.com/jsonbored/nightward/internal/inventory"
+	"github.com/jsonbored/nightward/internal/policy"
+	"github.com/jsonbored/nightward/internal/schedule"
+	"github.com/jsonbored/nightward/internal/snapshot"
+	"github.com/jsonbored/nightward/internal/tui"
 )
 
 const version = "0.1.0"
@@ -81,6 +82,12 @@ func RunWithName(commandName string, args []string, stdout, stderr io.Writer) in
 		return runFindings(home, args[1:], stdout, stderr)
 	case "fix":
 		return runFix(home, args[1:], stdout, stderr)
+	case "analyze":
+		return runAnalyze(home, args[1:], stdout, stderr)
+	case "trust":
+		return runTrust(home, args[1:], stdout, stderr)
+	case "providers":
+		return runProviders(args[1:], stdout, stderr)
 	case "policy":
 		return runPolicy(home, args[1:], stdout, stderr)
 	case "snapshot":
@@ -152,11 +159,15 @@ func runScan(home string, args []string, stdout, stderr io.Writer) int {
 	jsonOut := fs.Bool("json", false, "print JSON output")
 	output := fs.String("output", "", "write JSON report to a file")
 	outputDir := fs.String("output-dir", "", "write JSON report to a timestamped file in this directory")
+	workspace := fs.String("workspace", "", "scan a repository/workspace instead of HOME")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 
-	report := inventory.NewScanner(home).Scan()
+	report := scanReport(home, *workspace)
+	if *output == "-" {
+		return writeJSON(stdout, report, stderr)
+	}
 	if err := maybeWriteReport(report, *output, *outputDir); err != nil {
 		return fail(stderr, "failed to write scan report: %v", err)
 	}
@@ -351,6 +362,144 @@ func runFix(home string, args []string, stdout, stderr io.Writer) int {
 	return 0
 }
 
+func runAnalyze(home string, args []string, stdout, stderr io.Writer) int {
+	if len(args) > 0 && args[0] == "finding" {
+		ordered := flagsFirst(args[1:], map[string]bool{"--workspace": true, "--with": true})
+		fs := flag.NewFlagSet("analyze finding", flag.ContinueOnError)
+		fs.SetOutput(stderr)
+		jsonOut := fs.Bool("json", false, "print JSON output")
+		workspace := fs.String("workspace", "", "scan a repository/workspace instead of HOME")
+		with := fs.String("with", "", "comma-separated optional providers to enable")
+		online := fs.Bool("online", false, "allow explicitly selected network-capable providers")
+		if err := fs.Parse(ordered); err != nil {
+			return 2
+		}
+		if fs.NArg() != 1 {
+			return fail(stderr, "usage: nightward analyze finding <finding-id> [--json]")
+		}
+		_, analysisReport := analyzeReport(home, *workspace, analysis.Options{FindingID: fs.Arg(0), With: splitCSV(*with), Online: *online})
+		if len(analysisReport.Signals) != 1 {
+			return fail(stderr, "finding not found or ambiguous: %s", fs.Arg(0))
+		}
+		if *jsonOut {
+			return writeJSON(stdout, analysisReport, stderr)
+		}
+		printAnalysis(stdout, analysisReport)
+		return 0
+	}
+	if len(args) > 0 && args[0] == "package" {
+		ordered := flagsFirst(args[1:], map[string]bool{"--with": true})
+		fs := flag.NewFlagSet("analyze package", flag.ContinueOnError)
+		fs.SetOutput(stderr)
+		jsonOut := fs.Bool("json", false, "print JSON output")
+		with := fs.String("with", "", "comma-separated optional providers to enable")
+		online := fs.Bool("online", false, "allow explicitly selected network-capable providers")
+		if err := fs.Parse(ordered); err != nil {
+			return 2
+		}
+		if fs.NArg() != 1 {
+			return fail(stderr, "usage: nightward analyze package <package> [--json]")
+		}
+		analysisReport := analysis.Run(inventory.Report{GeneratedAt: time.Now().UTC()}, analysis.Options{Mode: "package", Package: fs.Arg(0), With: splitCSV(*with), Online: *online})
+		if *jsonOut {
+			return writeJSON(stdout, analysisReport, stderr)
+		}
+		printAnalysis(stdout, analysisReport)
+		return 0
+	}
+
+	fs := flag.NewFlagSet("analyze", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	all := fs.Bool("all", false, "analyze all discovered subjects")
+	jsonOut := fs.Bool("json", false, "print JSON output")
+	workspace := fs.String("workspace", "", "scan a repository/workspace instead of HOME")
+	with := fs.String("with", "", "comma-separated optional providers to enable")
+	online := fs.Bool("online", false, "allow explicitly selected network-capable providers")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if !*all {
+		return fail(stderr, "usage: nightward analyze --all [--json]")
+	}
+	_, analysisReport := analyzeReport(home, *workspace, analysis.Options{With: splitCSV(*with), Online: *online})
+	if *jsonOut {
+		return writeJSON(stdout, analysisReport, stderr)
+	}
+	printAnalysis(stdout, analysisReport)
+	return 0
+}
+
+func runTrust(home string, args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] != "explain" {
+		return fail(stderr, "usage: nightward trust explain <finding-id> [--json]")
+	}
+	ordered := flagsFirst(args[1:], map[string]bool{"--workspace": true})
+	fs := flag.NewFlagSet("trust explain", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	jsonOut := fs.Bool("json", false, "print JSON output")
+	workspace := fs.String("workspace", "", "scan a repository/workspace instead of HOME")
+	if err := fs.Parse(ordered); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		return fail(stderr, "usage: nightward trust explain <finding-id> [--json]")
+	}
+	_, analysisReport := analyzeReport(home, *workspace, analysis.Options{FindingID: fs.Arg(0)})
+	if len(analysisReport.Signals) != 1 {
+		return fail(stderr, "finding not found or ambiguous: %s", fs.Arg(0))
+	}
+	if *jsonOut {
+		return writeJSON(stdout, analysisReport.Signals[0], stderr)
+	}
+	printSignal(stdout, analysisReport.Signals[0])
+	return 0
+}
+
+func runProviders(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		return fail(stderr, "usage: nightward providers <list|doctor> [--json]")
+	}
+	switch args[0] {
+	case "list":
+		fs := flag.NewFlagSet("providers list", flag.ContinueOnError)
+		fs.SetOutput(stderr)
+		jsonOut := fs.Bool("json", false, "print JSON output")
+		if err := fs.Parse(args[1:]); err != nil {
+			return 2
+		}
+		providers := analysis.Providers()
+		if *jsonOut {
+			return writeJSON(stdout, providers, stderr)
+		}
+		for _, provider := range providers {
+			mode := "offline"
+			if provider.Online {
+				mode = "online-capable"
+			}
+			fmt.Fprintf(stdout, "%-12s %-14s %s\n", provider.Name, mode, provider.Capabilities)
+		}
+	case "doctor":
+		fs := flag.NewFlagSet("providers doctor", flag.ContinueOnError)
+		fs.SetOutput(stderr)
+		jsonOut := fs.Bool("json", false, "print JSON output")
+		with := fs.String("with", "", "comma-separated optional providers to enable")
+		online := fs.Bool("online", false, "allow explicitly selected network-capable providers")
+		if err := fs.Parse(args[1:]); err != nil {
+			return 2
+		}
+		statuses := analysis.ProviderStatuses(splitCSV(*with), *online)
+		if *jsonOut {
+			return writeJSON(stdout, statuses, stderr)
+		}
+		for _, status := range statuses {
+			fmt.Fprintf(stdout, "%-12s %-9s %-8t %s\n", status.Name, status.Status, status.Enabled, status.Detail)
+		}
+	default:
+		return fail(stderr, "usage: nightward providers <list|doctor> [--json]")
+	}
+	return 0
+}
+
 func runPolicy(home string, args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
 		return fail(stderr, "usage: nightward policy <init|explain|check|sarif> [flags]")
@@ -380,6 +529,8 @@ func runPolicy(home string, args []string, stdout, stderr io.Writer) int {
 		strict := fs.Bool("strict", false, "fail on medium or higher findings")
 		jsonOut := fs.Bool("json", false, "print JSON output")
 		configPath := fs.String("config", "", "optional .nightward.yml policy config")
+		workspace := fs.String("workspace", "", "scan a repository/workspace instead of HOME")
+		includeAnalysis := fs.Bool("include-analysis", false, "include offline analysis signals in policy decisions")
 		if err := fs.Parse(args[1:]); err != nil {
 			return 2
 		}
@@ -387,8 +538,13 @@ func runPolicy(home string, args []string, stdout, stderr io.Writer) int {
 		if err != nil {
 			return fail(stderr, "failed to load policy config: %v", err)
 		}
-		report := inventory.NewScanner(home).Scan()
-		policyReport := policy.CheckWithOptions(report, policy.Options{Strict: *strict, Config: config})
+		report := scanReport(home, *workspace)
+		mode := "home"
+		if *workspace != "" {
+			mode = "workspace"
+		}
+		analysisReport := analysis.Run(report, analysis.Options{Mode: mode, Workspace: report.Workspace, With: config.AnalysisProviders, Online: config.AllowOnlineProviders})
+		policyReport := policy.CheckWithOptions(report, policy.Options{Strict: *strict, Config: config, IncludeAnalysis: *includeAnalysis, Analysis: analysisReport})
 		if *jsonOut {
 			code := writeJSON(stdout, policyReport, stderr)
 			if code != 0 {
@@ -405,6 +561,8 @@ func runPolicy(home string, args []string, stdout, stderr io.Writer) int {
 		fs.SetOutput(stderr)
 		output := fs.String("output", "nightward.sarif", "write SARIF report to this path")
 		configPath := fs.String("config", "", "optional .nightward.yml policy config")
+		workspace := fs.String("workspace", "", "scan a repository/workspace instead of HOME")
+		includeAnalysis := fs.Bool("include-analysis", false, "include offline analysis signals in SARIF output")
 		if err := fs.Parse(args[1:]); err != nil {
 			return 2
 		}
@@ -412,8 +570,22 @@ func runPolicy(home string, args []string, stdout, stderr io.Writer) int {
 		if err != nil {
 			return fail(stderr, "failed to load policy config: %v", err)
 		}
-		report := inventory.NewScanner(home).Scan()
-		if err := policy.WriteSARIFWithConfig(report, *output, config); err != nil {
+		report := scanReport(home, *workspace)
+		var sarif map[string]any
+		if *includeAnalysis || config.IncludeAnalysis {
+			mode := "home"
+			if *workspace != "" {
+				mode = "workspace"
+			}
+			analysisReport := analysis.Run(report, analysis.Options{Mode: mode, Workspace: report.Workspace, With: config.AnalysisProviders, Online: config.AllowOnlineProviders})
+			sarif = policy.BuildSARIFWithAnalysis(report, analysisReport, config)
+		} else {
+			sarif = policy.BuildSARIFWithConfig(report, config)
+		}
+		if *output == "-" {
+			return writeJSON(stdout, sarif, stderr)
+		}
+		if err := policy.WriteSARIFObject(sarif, *output); err != nil {
 			return fail(stderr, "failed to write SARIF: %v", err)
 		}
 		fmt.Fprintf(stdout, "Wrote SARIF policy report to %s\n", *output)
@@ -581,7 +753,7 @@ func printHelp(w io.Writer, commandName string) {
 
 Usage:
   %[1]s                                Open the TUI
-  %[1]s scan [--json] [--output FILE] [--output-dir DIR]
+  %[1]s scan [--json] [--workspace DIR] [--output FILE|-] [--output-dir DIR]
   %[1]s doctor [--json]
   %[1]s plan backup --target <repo> [--json]
   %[1]s adapters list [--json]
@@ -590,10 +762,16 @@ Usage:
   %[1]s fix plan [--finding <id>|--rule <rule>|--all] [--json]
   %[1]s fix preview [--finding <id>|--rule <rule>|--all] [--format diff|json|markdown]
   %[1]s fix export --format markdown|json
+  %[1]s analyze --all [--workspace DIR] [--with providers] [--online] [--json]
+  %[1]s analyze finding <finding-id> [--workspace DIR] [--json]
+  %[1]s analyze package <package> [--with providers] [--online] [--json]
+  %[1]s trust explain <finding-id> [--workspace DIR] [--json]
+  %[1]s providers list [--json]
+  %[1]s providers doctor [--with providers] [--online] [--json]
   %[1]s policy init --dry-run
   %[1]s policy explain
-  %[1]s policy check [--config .nightward.yml] [--strict] [--json]
-  %[1]s policy sarif [--config .nightward.yml] --output nightward.sarif
+  %[1]s policy check [--config .nightward.yml] [--workspace DIR] [--include-analysis] [--strict] [--json]
+  %[1]s policy sarif [--config .nightward.yml] [--workspace DIR] [--include-analysis] --output nightward.sarif|-
   %[1]s snapshot plan --target <dir> [--json]
   %[1]s snapshot diff --from <plan.json> --to <plan.json> [--json]
   %[1]s schedule plan --preset nightly [--json]
@@ -707,9 +885,50 @@ func printPolicy(w io.Writer, report policy.Report) {
 	if !report.Passed {
 		status = "failed"
 	}
-	fmt.Fprintf(w, "Nightward policy %s: threshold=%s violations=%d total_findings=%d\n", status, report.Threshold, report.Summary.Violations, report.Summary.TotalFindings)
+	fmt.Fprintf(w, "Nightward policy %s: threshold=%s violations=%d signal_violations=%d total_findings=%d\n", status, report.Threshold, report.Summary.Violations, report.Summary.SignalViolations, report.Summary.TotalFindings)
 	for _, finding := range report.Violations {
 		fmt.Fprintf(w, "  [%s] %s %s\n", finding.Severity, finding.Rule, finding.ID)
+	}
+	for _, signal := range report.SignalViolations {
+		fmt.Fprintf(w, "  [%s] %s %s\n", signal.Severity, signal.Rule, signal.ID)
+	}
+}
+
+func printAnalysis(w io.Writer, report analysis.Report) {
+	status := "no known risky signals"
+	if report.Summary.TotalSignals > 0 {
+		status = fmt.Sprintf("%d signals, highest=%s", report.Summary.TotalSignals, report.Summary.HighestSeverity)
+	}
+	fmt.Fprintf(w, "Nightward analysis: %s\n", status)
+	if report.Summary.ProviderWarnings > 0 {
+		fmt.Fprintf(w, "Provider warnings: %d\n", report.Summary.ProviderWarnings)
+	}
+	if len(report.Signals) > 0 {
+		fmt.Fprintln(w, "Top signals:")
+		for i, signal := range report.Signals {
+			if i >= 8 {
+				break
+			}
+			fmt.Fprintf(w, "  [%s] %-30s %s\n", signal.Severity, signal.Rule, signal.Message)
+		}
+	}
+}
+
+func printSignal(w io.Writer, signal analysis.Signal) {
+	fmt.Fprintf(w, "%s\n", signal.ID)
+	fmt.Fprintf(w, "  rule:       %s\n", signal.Rule)
+	fmt.Fprintf(w, "  severity:   %s\n", signal.Severity)
+	fmt.Fprintf(w, "  confidence: %s\n", signal.Confidence)
+	fmt.Fprintf(w, "  provider:   %s\n", signal.Provider)
+	if signal.Path != "" {
+		fmt.Fprintf(w, "  path:       %s\n", signal.Path)
+	}
+	if signal.Evidence != "" {
+		fmt.Fprintf(w, "  evidence:   %s\n", signal.Evidence)
+	}
+	fmt.Fprintf(w, "\nRecommendation: %s\n", signal.Recommendation)
+	if signal.Why != "" {
+		fmt.Fprintf(w, "Why this matters: %s\n", signal.Why)
 	}
 }
 
@@ -774,6 +993,66 @@ func fixSelector(report inventory.Report, findingID, rule string, all bool) (fix
 		findingID = finding.ID
 	}
 	return fixplan.Selector{FindingID: findingID, Rule: rule, All: all}, nil
+}
+
+func scanReport(home, workspace string) inventory.Report {
+	if workspace != "" {
+		return inventory.NewWorkspaceScanner(expandHome(home, workspace)).Scan()
+	}
+	return inventory.NewScanner(home).Scan()
+}
+
+func analyzeReport(home, workspace string, options analysis.Options) (inventory.Report, analysis.Report) {
+	report := scanReport(home, workspace)
+	options.Workspace = report.Workspace
+	if options.Mode == "" {
+		options.Mode = "home"
+		if workspace != "" {
+			options.Mode = "workspace"
+		}
+	}
+	return report, analysis.Run(report, options)
+}
+
+func splitCSV(value string) []string {
+	if value == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func flagsFirst(args []string, valueFlags map[string]bool) []string {
+	var flags []string
+	var rest []string
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			rest = append(rest, args[i+1:]...)
+			break
+		}
+		if strings.HasPrefix(arg, "--") {
+			flags = append(flags, arg)
+			name := arg
+			if eq := strings.IndexByte(name, '='); eq >= 0 {
+				name = name[:eq]
+			}
+			if valueFlags[name] && !strings.Contains(arg, "=") && i+1 < len(args) {
+				i++
+				flags = append(flags, args[i])
+			}
+			continue
+		}
+		rest = append(rest, arg)
+	}
+	return append(flags, rest...)
 }
 
 func writeJSON(w io.Writer, value any, stderr io.Writer) int {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -13,12 +13,15 @@ func TestReadOnlyCommandsDoNotMutateHome(t *testing.T) {
 	home := t.TempDir()
 	writeTestFile(t, filepath.Join(home, ".mcp.json"), `{"mcpServers":{"demo":{"command":"node","args":["server.js"]}}}`)
 	outputDir := t.TempDir()
+	targetDir := filepath.Join(t.TempDir(), "backup-target")
 	t.Setenv("NIGHTWARD_HOME", home)
 
 	before := listTestFiles(t, home)
+	targetBefore := listOptionalTestFiles(t, targetDir)
 	commands := [][]string{
 		{"scan", "--json"},
 		{"doctor", "--json"},
+		{"plan", "backup", "--target", targetDir, "--json"},
 		{"findings", "list", "--json"},
 		{"fix", "plan", "--all", "--json"},
 		{"fix", "preview", "--all", "--format", "json"},
@@ -35,9 +38,17 @@ func TestReadOnlyCommandsDoNotMutateHome(t *testing.T) {
 			t.Fatalf("%s failed with %d: %s", strings.Join(args, " "), code, stderr.String())
 		}
 	}
+	var stdout, stderr bytes.Buffer
+	if code := RunWithName("nw", []string{"findings", "explain", "--json", "mcp_server_review"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("findings explain failed with %d: %s", code, stderr.String())
+	}
 	after := listTestFiles(t, home)
 	if strings.Join(before, "\n") != strings.Join(after, "\n") {
 		t.Fatalf("read-only commands mutated home\nbefore=%v\nafter=%v", before, after)
+	}
+	targetAfter := listOptionalTestFiles(t, targetDir)
+	if strings.Join(targetBefore, "\n") != strings.Join(targetAfter, "\n") {
+		t.Fatalf("read-only backup plan mutated target\nbefore=%v\nafter=%v", targetBefore, targetAfter)
 	}
 }
 
@@ -124,4 +135,12 @@ func listTestFiles(t *testing.T, root string) []string {
 		t.Fatal(err)
 	}
 	return out
+}
+
+func listOptionalTestFiles(t *testing.T, root string) []string {
+	t.Helper()
+	if _, err := os.Stat(root); os.IsNotExist(err) {
+		return nil
+	}
+	return listTestFiles(t, root)
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -26,11 +26,16 @@ func TestReadOnlyCommandsDoNotMutateHome(t *testing.T) {
 		{"fix", "plan", "--all", "--json"},
 		{"fix", "preview", "--all", "--format", "json"},
 		{"fix", "export", "--format", "markdown"},
+		{"analyze", "--all", "--json"},
+		{"providers", "list", "--json"},
+		{"providers", "doctor", "--json"},
 		{"policy", "check", "--json"},
+		{"policy", "check", "--include-analysis", "--json"},
 		{"policy", "init", "--dry-run"},
 		{"policy", "explain"},
 		{"snapshot", "plan", "--target", filepath.Join(home, "snapshot"), "--json"},
 		{"policy", "sarif", "--output", filepath.Join(outputDir, "nightward.sarif")},
+		{"policy", "sarif", "--include-analysis", "--output", "-"},
 	}
 	for _, args := range commands {
 		var stdout, stderr bytes.Buffer
@@ -49,6 +54,38 @@ func TestReadOnlyCommandsDoNotMutateHome(t *testing.T) {
 	targetAfter := listOptionalTestFiles(t, targetDir)
 	if strings.Join(targetBefore, "\n") != strings.Join(targetAfter, "\n") {
 		t.Fatalf("read-only backup plan mutated target\nbefore=%v\nafter=%v", targetBefore, targetAfter)
+	}
+}
+
+func TestWorkspaceCommandsAreReadOnlyAndSupportStdoutSARIF(t *testing.T) {
+	workspace := t.TempDir()
+	writeTestFile(t, filepath.Join(workspace, ".cursor", "mcp.json"), `{"mcpServers":{"demo":{"url":"http://127.0.0.1:8787/mcp","headers":{"Authorization":"Bearer super-secret-value"}}}}`)
+	before := listTestFiles(t, workspace)
+
+	commands := [][]string{
+		{"scan", "--workspace", workspace, "--json"},
+		{"scan", "--workspace", workspace, "--output", "-"},
+		{"analyze", "--all", "--workspace", workspace, "--json"},
+		{"policy", "check", "--workspace", workspace, "--include-analysis", "--json"},
+		{"policy", "sarif", "--workspace", workspace, "--include-analysis", "--output", "-"},
+	}
+	for _, args := range commands {
+		var stdout, stderr bytes.Buffer
+		code := RunWithName("nw", args, &stdout, &stderr)
+		if args[0] == "policy" && args[1] == "check" {
+			if code != 1 {
+				t.Fatalf("expected policy check to report violations, got %d: %s", code, stderr.String())
+			}
+		} else if code != 0 {
+			t.Fatalf("%s failed with %d: %s", strings.Join(args, " "), code, stderr.String())
+		}
+		if stdout.Len() == 0 {
+			t.Fatalf("%s produced no stdout", strings.Join(args, " "))
+		}
+	}
+	after := listTestFiles(t, workspace)
+	if strings.Join(before, "\n") != strings.Join(after, "\n") {
+		t.Fatalf("workspace commands mutated files\nbefore=%v\nafter=%v", before, after)
 	}
 }
 

--- a/internal/fixplan/plan.go
+++ b/internal/fixplan/plan.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/shadowbook/nightward/internal/inventory"
+	"github.com/jsonbored/nightward/internal/inventory"
 )
 
 type Status string

--- a/internal/fixplan/plan_test.go
+++ b/internal/fixplan/plan_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shadowbook/nightward/internal/inventory"
+	"github.com/jsonbored/nightward/internal/inventory"
 )
 
 func TestBuildGroupsFixStatusesAndRedacts(t *testing.T) {

--- a/internal/fixplan/preview.go
+++ b/internal/fixplan/preview.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jsonbored/nightward/internal/inventory"
 	"github.com/pelletier/go-toml/v2"
-	"github.com/shadowbook/nightward/internal/inventory"
 )
 
 type Preview struct {

--- a/internal/fixplan/preview.go
+++ b/internal/fixplan/preview.go
@@ -217,7 +217,7 @@ func previewReplaceShellWrapper(patch PatchPreview, parsed parsedMCP, hint *inve
 }
 
 func parseMCPServer(path, serverName string) (parsedMCP, error) {
-	contents, err := os.ReadFile(path)
+	contents, err := os.ReadFile(filepath.Clean(path)) // #nosec G304 -- preview reads scanner-discovered local MCP config without mutating it.
 	if err != nil {
 		return parsedMCP{}, err
 	}

--- a/internal/inventory/golden_test.go
+++ b/internal/inventory/golden_test.go
@@ -1,0 +1,69 @@
+package inventory
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGoldenScanSummaryAndURLFindings(t *testing.T) {
+	home := filepath.Clean("/tmp/nightward-golden-home")
+	if err := os.RemoveAll(home); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(home) })
+
+	writeFile(t, filepath.Join(home, ".codex", "config.toml"), `
+[mcp_servers.remote]
+url = "https://mcp.example.test/sse"
+
+[mcp_servers.local]
+url = "http://127.0.0.1:8787/mcp"
+
+[mcp_servers.header]
+type = "sse"
+url = "https://headers.example.test/mcp"
+
+[mcp_servers.header.headers]
+Authorization = "Bearer super-header-secret"
+X-API-Key = "${MCP_API_KEY}"
+
+[mcp_servers.unknown]
+type = "custom"
+`)
+
+	scanner := NewScanner(home)
+	scanner.Hostname = "fixture-host"
+	scanner.Now = func() time.Time { return time.Date(2026, 4, 30, 7, 0, 0, 0, time.UTC) }
+	report := scanner.Scan()
+
+	assertGoldenJSON(t, "testdata/golden/scan-summary.golden.json", report.Summary)
+	assertGoldenJSON(t, "testdata/golden/url-findings.golden.json", report.Findings)
+
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "super-header-secret") {
+		t.Fatal("golden fixture scan leaked header secret")
+	}
+}
+
+func assertGoldenJSON(t *testing.T, path string, value any) {
+	t.Helper()
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual := string(data) + "\n"
+	expected, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read golden %s: %v\nactual:\n%s", path, err, actual)
+	}
+	if string(expected) != actual {
+		t.Fatalf("golden mismatch for %s\nexpected:\n%s\nactual:\n%s", path, expected, actual)
+	}
+}

--- a/internal/inventory/mcp.go
+++ b/internal/inventory/mcp.go
@@ -73,7 +73,7 @@ func inspectMCP(item Item, spec pathSpec) []Finding {
 }
 
 func readMCPServers(path string) ([]mcpServer, error) {
-	contents, err := os.ReadFile(path)
+	contents, err := os.ReadFile(filepath.Clean(path)) // #nosec G304 -- MCP config path comes from Nightward's local adapter inventory.
 	if err != nil {
 		return nil, err
 	}

--- a/internal/inventory/mcp.go
+++ b/internal/inventory/mcp.go
@@ -3,6 +3,8 @@ package inventory
 import (
 	"encoding/json"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -13,11 +15,15 @@ import (
 )
 
 type mcpServer struct {
-	Name    string
-	Command string
-	Args    []string
-	Env     map[string]string
-	Raw     map[string]any
+	Name      string
+	Command   string
+	Args      []string
+	Env       map[string]string
+	URL       string
+	Type      string
+	Transport string
+	Headers   map[string]string
+	Raw       map[string]any
 }
 
 var secretKeyPattern = regexp.MustCompile(`(?i)(token|secret|password|passwd|api[_-]?key|auth|credential|private[_-]?key)`)
@@ -59,6 +65,8 @@ func inspectMCP(item Item, spec pathSpec) []Finding {
 		findings = append(findings, reviewFinding(item, server))
 		findings = append(findings, commandFindings(item, server)...)
 		findings = append(findings, envFindings(item, server)...)
+		findings = append(findings, headerFindings(item, server)...)
+		findings = append(findings, urlFindings(item, server)...)
 		findings = append(findings, argFindings(item, server)...)
 	}
 	return findings
@@ -121,14 +129,14 @@ func mapServers(group map[string]any) []mcpServer {
 		if !ok {
 			continue
 		}
-		server := mcpServer{Name: name, Raw: serverMap, Env: map[string]string{}}
+		server := mcpServer{Name: name, Raw: serverMap, Env: map[string]string{}, Headers: map[string]string{}}
 		server.Command = stringValue(serverMap["command"])
 		server.Args = stringSlice(serverMap["args"])
-		if env, ok := serverMap["env"].(map[string]any); ok {
-			for key, value := range env {
-				server.Env[key] = stringValue(value)
-			}
-		}
+		server.URL = stringValue(serverMap["url"])
+		server.Type = stringValue(serverMap["type"])
+		server.Transport = stringValue(serverMap["transport"])
+		server.Env = stringMap(serverMap["env"])
+		server.Headers = stringMap(serverMap["headers"])
 		servers = append(servers, server)
 	}
 	return servers
@@ -139,6 +147,10 @@ func reviewFinding(item Item, server mcpServer) Finding {
 	if command == "" {
 		command = "unknown"
 	}
+	evidence := fmt.Sprintf("command=%s", redact(command))
+	if server.URL != "" && server.Command == "" {
+		evidence = remoteEvidence(server)
+	}
 	return Finding{
 		ID:             findingID("mcp_server_review", item.Tool, item.Path, server.Name),
 		Tool:           item.Tool,
@@ -147,7 +159,7 @@ func reviewFinding(item Item, server mcpServer) Finding {
 		Severity:       RiskInfo,
 		Rule:           "mcp_server_review",
 		Message:        fmt.Sprintf("Review MCP server %q before syncing this config.", server.Name),
-		Evidence:       fmt.Sprintf("command=%s", redact(command)),
+		Evidence:       evidence,
 		Recommendation: "Confirm the server source, permissions, and local path assumptions.",
 		Impact:         "This server may execute local code or expose local files when an AI client invokes it.",
 		Why:            "MCP configs are executable trust boundaries, so portable backups should preserve intent without hiding local-only risk.",
@@ -255,7 +267,7 @@ func commandFindings(item Item, server mcpServer) []Finding {
 		findings = append(findings, finding)
 	}
 
-	if server.Command == "" {
+	if server.Command == "" && server.URL == "" {
 		findings = append(findings, Finding{
 			ID:             findingID("mcp_unknown_command", item.Tool, item.Path, server.Name),
 			Tool:           item.Tool,
@@ -264,6 +276,7 @@ func commandFindings(item Item, server mcpServer) []Finding {
 			Severity:       RiskMedium,
 			Rule:           "mcp_unknown_command",
 			Message:        fmt.Sprintf("MCP server %q does not declare a command Nightward can inspect.", server.Name),
+			Evidence:       structuralEvidence(server),
 			Recommendation: "Review this server manually before syncing.",
 			Impact:         "Nightward cannot determine what executable would run for this MCP server.",
 			Why:            "Missing or unsupported server shapes block reliable policy checks and backup decisions.",
@@ -341,6 +354,96 @@ func envFindings(item Item, server mcpServer) []Finding {
 		}
 	}
 	return findings
+}
+
+func headerFindings(item Item, server mcpServer) []Finding {
+	var findings []Finding
+	keys := make([]string, 0, len(server.Headers))
+	for key := range server.Headers {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if !secretKeyPattern.MatchString(key) {
+			continue
+		}
+		value := server.Headers[key]
+		referenceOnly := value == "" || looksEnvReference(value)
+		severity := RiskCritical
+		risk := RiskHigh
+		message := fmt.Sprintf("MCP server %q stores a sensitive header.", server.Name)
+		summary := fmt.Sprintf("Move the %s header value out of this config and into a local secret source.", key)
+		steps := []string{
+			fmt.Sprintf("Remove the inline value for the %s header from the MCP config.", key),
+			fmt.Sprintf("Set %s in your shell profile, launchd environment, password manager CLI, or another local secret source.", envNameForHeader(key)),
+			"Keep only the header name or documented local setup prerequisite in portable dotfiles.",
+		}
+		confidence := "high"
+		if referenceOnly {
+			severity = RiskMedium
+			risk = RiskLow
+			message = fmt.Sprintf("MCP server %q references a sensitive header.", server.Name)
+			summary = fmt.Sprintf("Document the %s header as a local prerequisite without committing its value.", key)
+			steps = []string{
+				fmt.Sprintf("Confirm the %s header is only referenced by name or environment interpolation.", key),
+				"Document how to provide the secret locally without adding the value to dotfiles.",
+				"Keep the real value in a password manager, OS keychain, or machine-local env file excluded from Git.",
+			}
+			confidence = "medium"
+		}
+		findings = append(findings, Finding{
+			ID:             findingID("mcp_secret_header", item.Tool, item.Path, server.Name+key),
+			Tool:           item.Tool,
+			Path:           item.Path,
+			Server:         server.Name,
+			Severity:       severity,
+			Rule:           "mcp_secret_header",
+			Message:        message,
+			Evidence:       fmt.Sprintf("header_key=%s", key),
+			Recommendation: "Keep sensitive header values outside dotfiles and document required header names only.",
+			Impact:         "Credential-bearing headers in agent config can leak through dotfiles, backups, screenshots, or support bundles.",
+			Why:            "Remote MCP servers often use headers for authentication, so values should stay in dedicated local secret stores.",
+			FixAvailable:   true,
+			FixKind:        FixExternalizeSecret,
+			Confidence:     confidence,
+			Risk:           risk,
+			RequiresReview: true,
+			FixSummary:     summary,
+			FixSteps:       steps,
+			PatchHint:      &PatchHint{Kind: FixExternalizeSecret, EnvKey: envNameForHeader(key), InlineSecret: !referenceOnly},
+		})
+	}
+	return findings
+}
+
+func urlFindings(item Item, server mcpServer) []Finding {
+	if server.URL == "" || !isLocalEndpoint(server.URL) {
+		return nil
+	}
+	return []Finding{{
+		ID:             findingID("mcp_local_endpoint", item.Tool, item.Path, server.Name),
+		Tool:           item.Tool,
+		Path:           item.Path,
+		Server:         server.Name,
+		Severity:       RiskMedium,
+		Rule:           "mcp_local_endpoint",
+		Message:        fmt.Sprintf("MCP server %q points at a local or private endpoint.", server.Name),
+		Evidence:       remoteEvidence(server),
+		Recommendation: "Keep local endpoint assumptions machine-local unless intentionally templated.",
+		Impact:         "Local or private MCP endpoints may not exist on another machine and can reveal local network assumptions.",
+		Why:            "Portable dotfiles should distinguish remote service configuration from machine-local development endpoints.",
+		FixAvailable:   true,
+		FixKind:        FixManualReview,
+		Confidence:     "medium",
+		Risk:           RiskLow,
+		RequiresReview: true,
+		FixSummary:     "Move local endpoint assumptions into a machine-local overlay or document them as setup prerequisites.",
+		FixSteps: []string{
+			"Confirm whether this MCP endpoint is intentionally machine-local.",
+			"Keep the URL in an ignored local overlay if it is not portable.",
+			"Document the expected local service when the endpoint is required for this machine.",
+		},
+	}}
 }
 
 func argFindings(item Item, server mcpServer) []Finding {
@@ -553,11 +656,89 @@ func referencesTokenPath(args []string) bool {
 	return false
 }
 
+func remoteEvidence(server mcpServer) string {
+	transport := "remote-url"
+	if server.Transport != "" {
+		transport = server.Transport
+	}
+	serverType := server.Type
+	if serverType == "" {
+		serverType = "unknown"
+	}
+	return fmt.Sprintf("transport=%s type=%s url=%s", transport, serverType, redactURL(server.URL))
+}
+
+func redactURL(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed == nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "[redacted-url]"
+	}
+	return parsed.Scheme + "://" + parsed.Host
+}
+
+func structuralEvidence(server mcpServer) string {
+	keys := make([]string, 0, len(server.Raw))
+	for key := range server.Raw {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	if len(keys) == 0 {
+		return "keys=[]"
+	}
+	return "keys=[" + strings.Join(keys, ",") + "]"
+}
+
+func isLocalEndpoint(raw string) bool {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed == nil || parsed.Host == "" {
+		return false
+	}
+	host := parsed.Hostname()
+	if host == "" {
+		host = parsed.Host
+		if splitHost, _, err := net.SplitHostPort(parsed.Host); err == nil {
+			host = splitHost
+		}
+	}
+	host = strings.Trim(strings.ToLower(host), "[]")
+	if host == "localhost" || host == "0.0.0.0" || strings.HasSuffix(host, ".local") || strings.HasSuffix(host, ".localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsUnspecified()
+}
+
+func envNameForHeader(header string) string {
+	name := strings.ToUpper(header)
+	replacer := strings.NewReplacer("-", "_", " ", "_", ".", "_")
+	name = replacer.Replace(name)
+	name = strings.Trim(name, "_")
+	if name == "" {
+		return "MCP_HEADER_VALUE"
+	}
+	return name
+}
+
 func stringValue(v any) string {
 	if s, ok := v.(string); ok {
 		return s
 	}
 	return ""
+}
+
+func stringMap(v any) map[string]string {
+	out := map[string]string{}
+	values, ok := v.(map[string]any)
+	if !ok {
+		return out
+	}
+	for key, value := range values {
+		out[key] = stringValue(value)
+	}
+	return out
 }
 
 func stringSlice(v any) []string {

--- a/internal/inventory/scanner.go
+++ b/internal/inventory/scanner.go
@@ -49,9 +49,12 @@ func (s Scanner) Scan() Report {
 		Hostname:    s.Hostname,
 		Home:        s.Home,
 		Summary: Summary{
-			ByClassification: map[Classification]int{},
-			ByRisk:           map[RiskLevel]int{},
-			Tools:            map[string]int{},
+			ItemsByClassification: map[Classification]int{},
+			ItemsByRisk:           map[RiskLevel]int{},
+			ItemsByTool:           map[string]int{},
+			FindingsBySeverity:    map[RiskLevel]int{},
+			FindingsByRule:        map[string]int{},
+			FindingsByTool:        map[string]int{},
 		},
 	}
 
@@ -96,9 +99,14 @@ func (s Scanner) Scan() Report {
 	report.Summary.TotalItems = len(report.Items)
 	report.Summary.TotalFindings = len(report.Findings)
 	for _, item := range report.Items {
-		report.Summary.ByClassification[item.Classification]++
-		report.Summary.ByRisk[item.Risk]++
-		report.Summary.Tools[item.Tool]++
+		report.Summary.ItemsByClassification[item.Classification]++
+		report.Summary.ItemsByRisk[item.Risk]++
+		report.Summary.ItemsByTool[item.Tool]++
+	}
+	for _, finding := range report.Findings {
+		report.Summary.FindingsBySeverity[finding.Severity]++
+		report.Summary.FindingsByRule[finding.Rule]++
+		report.Summary.FindingsByTool[finding.Tool]++
 	}
 
 	return report

--- a/internal/inventory/scanner.go
+++ b/internal/inventory/scanner.go
@@ -1,7 +1,7 @@
 package inventory
 
 import (
-	"crypto/sha1"
+	"crypto/sha1" // #nosec G505 -- used only for short deterministic non-security IDs.
 	"encoding/hex"
 	"fmt"
 	"os"
@@ -260,7 +260,7 @@ func inspectPath(path string, spec pathSpec) (Item, bool) {
 }
 
 func stableID(parts ...string) string {
-	hash := sha1.Sum([]byte(strings.Join(parts, "\x00")))
+	hash := sha1.Sum([]byte(strings.Join(parts, "\x00"))) // #nosec G401 -- stable label only, not a cryptographic control.
 	return hex.EncodeToString(hash[:])[:12]
 }
 

--- a/internal/inventory/scanner.go
+++ b/internal/inventory/scanner.go
@@ -12,9 +12,10 @@ import (
 )
 
 type Scanner struct {
-	Home     string
-	Hostname string
-	Now      func() time.Time
+	Home      string
+	Workspace string
+	Hostname  string
+	Now       func() time.Time
 }
 
 type pathSpec struct {
@@ -42,12 +43,28 @@ func NewScanner(home string) Scanner {
 	return Scanner{Home: home, Hostname: host, Now: time.Now}
 }
 
+func NewWorkspaceScanner(root string) Scanner {
+	if root == "" {
+		root = "."
+	}
+	abs, err := filepath.Abs(root)
+	if err == nil {
+		root = abs
+	}
+	host, _ := os.Hostname()
+	return Scanner{Workspace: root, Hostname: host, Now: time.Now}
+}
+
 func (s Scanner) Scan() Report {
 	now := s.now()
+	if s.Workspace != "" {
+		return s.scanWorkspace(now)
+	}
 	report := Report{
 		GeneratedAt: now,
 		Hostname:    s.Hostname,
 		Home:        s.Home,
+		ScanMode:    "home",
 		Summary: Summary{
 			ItemsByClassification: map[Classification]int{},
 			ItemsByRisk:           map[RiskLevel]int{},
@@ -112,6 +129,54 @@ func (s Scanner) Scan() Report {
 	return report
 }
 
+func (s Scanner) scanWorkspace(now time.Time) Report {
+	report := Report{
+		GeneratedAt: now,
+		Hostname:    s.Hostname,
+		Home:        "",
+		Workspace:   s.Workspace,
+		ScanMode:    "workspace",
+		Summary: Summary{
+			ItemsByClassification: map[Classification]int{},
+			ItemsByRisk:           map[RiskLevel]int{},
+			ItemsByTool:           map[string]int{},
+			FindingsBySeverity:    map[RiskLevel]int{},
+			FindingsByRule:        map[string]int{},
+			FindingsByTool:        map[string]int{},
+		},
+	}
+
+	for _, adapter := range workspaceAdapters() {
+		status := AdapterStatus{
+			Name:        adapter.Name,
+			Description: adapter.Description,
+		}
+		for _, spec := range adapter.Paths {
+			path := filepath.Join(s.Workspace, filepath.FromSlash(spec.RelPath))
+			status.Checked = append(status.Checked, path)
+			item, ok := inspectPath(path, spec)
+			if !ok {
+				continue
+			}
+			item.ID = stableID("workspace", item.Tool, item.Path)
+			if item.Metadata == nil {
+				item.Metadata = map[string]string{}
+			}
+			item.Metadata["source"] = "nightward-workspace"
+			report.Items = append(report.Items, item)
+			status.Available = true
+			status.Found = append(status.Found, path)
+			report.Findings = append(report.Findings, inspectMCP(item, spec)...)
+		}
+		sort.Strings(status.Checked)
+		sort.Strings(status.Found)
+		report.Adapters = append(report.Adapters, status)
+	}
+
+	finalizeReport(&report)
+	return report
+}
+
 func (s Scanner) now() time.Time {
 	if s.Now != nil {
 		return s.Now().UTC()
@@ -127,6 +192,37 @@ func (s Scanner) expand(rel string) string {
 		return s.Home
 	}
 	return rel
+}
+
+func finalizeReport(report *Report) {
+	sort.Slice(report.Items, func(i, j int) bool {
+		if report.Items[i].Tool == report.Items[j].Tool {
+			return report.Items[i].Path < report.Items[j].Path
+		}
+		return report.Items[i].Tool < report.Items[j].Tool
+	})
+	sort.Slice(report.Findings, func(i, j int) bool {
+		if report.Findings[i].Severity == report.Findings[j].Severity {
+			if report.Findings[i].Rule == report.Findings[j].Rule {
+				return report.Findings[i].Path < report.Findings[j].Path
+			}
+			return report.Findings[i].Rule < report.Findings[j].Rule
+		}
+		return severityRank(report.Findings[i].Severity) > severityRank(report.Findings[j].Severity)
+	})
+
+	report.Summary.TotalItems = len(report.Items)
+	report.Summary.TotalFindings = len(report.Findings)
+	for _, item := range report.Items {
+		report.Summary.ItemsByClassification[item.Classification]++
+		report.Summary.ItemsByRisk[item.Risk]++
+		report.Summary.ItemsByTool[item.Tool]++
+	}
+	for _, finding := range report.Findings {
+		report.Summary.FindingsBySeverity[finding.Severity]++
+		report.Summary.FindingsByRule[finding.Rule]++
+		report.Summary.FindingsByTool[finding.Tool]++
+	}
 }
 
 func inspectPath(path string, spec pathSpec) (Item, bool) {
@@ -363,6 +459,70 @@ func adapters() []adapterSpec {
 			Paths: []pathSpec{
 				portable("Generic MCP", "~/.mcp.json", "Standalone MCP config should be reviewed before syncing.", true),
 				portable("Generic MCP", "~/.config/mcp/mcp.json", "Standalone MCP config should be reviewed before syncing.", true),
+			},
+		},
+	}
+}
+
+func workspaceAdapters() []adapterSpec {
+	return []adapterSpec{
+		{
+			Name:        "Workspace Codex",
+			Description: "Codex project instructions and repo-local MCP config.",
+			Paths: []pathSpec{
+				portable("Codex", ".codex/config.toml", "Repo-local Codex MCP config should be reviewed before CI or dotfile sync.", true),
+				portable("Codex", "AGENTS.md", "Project instruction files are portable but can encode machine assumptions.", false),
+				portableDir("Codex", ".codex/skills", "Repo-local Codex skills are portable after secret and path review."),
+			},
+		},
+		{
+			Name:        "Workspace Claude",
+			Description: "Claude project settings, agents, commands, and MCP config.",
+			Paths: []pathSpec{
+				portable("Claude", ".claude/settings.json", "Claude settings are portable after provider and path review.", false),
+				portable("Claude", ".claude/mcp.json", "Claude MCP config should be reviewed before CI or dotfile sync.", true),
+				portableDir("Claude", ".claude/commands", "Claude commands are usually portable project guidance."),
+				portableDir("Claude", ".claude/agents", "Claude agents are usually portable project guidance."),
+			},
+		},
+		{
+			Name:        "Workspace Cursor",
+			Description: "Cursor repo rules, skills, settings, and MCP config.",
+			Paths: []pathSpec{
+				portable("Cursor", ".cursor/mcp.json", "Cursor MCP config should be reviewed before CI or dotfile sync.", true),
+				portable("Cursor", ".cursor/settings.json", "Cursor repo settings are portable after provider and path review.", false),
+				portableDir("Cursor", ".cursor/rules", "Cursor rules are usually portable project guidance."),
+				portableDir("Cursor", ".cursor/skills-cursor", "Cursor skills are usually portable after review."),
+			},
+		},
+		{
+			Name:        "Workspace Editors",
+			Description: "Editor and assistant configs commonly committed to repos.",
+			Paths: []pathSpec{
+				portable("VS Code", ".vscode/mcp.json", "VS Code MCP config should be reviewed before CI or dotfile sync.", true),
+				portable("VS Code", ".vscode/settings.json", "VS Code repo settings are portable after path review.", false),
+				portable("Windsurf", ".windsurf/mcp.json", "Windsurf MCP config should be reviewed before CI or dotfile sync.", true),
+				portable("Zed", ".zed/settings.json", "Zed repo settings are portable after provider and path review.", false),
+				portable("Continue", ".continue/config.json", "Continue config is portable after provider, model, and path review.", true),
+				portable("OpenCode", ".opencode.json", "OpenCode config is portable after provider and path review.", true),
+				portable("Generic MCP", ".mcp.json", "Standalone MCP config should be reviewed before CI or dotfile sync.", true),
+				portable("Generic MCP", "mcp.json", "Standalone MCP config should be reviewed before CI or dotfile sync.", true),
+			},
+		},
+		{
+			Name:        "Workspace Secrets",
+			Description: "Credential-like files that should not be committed or synced.",
+			Paths: []pathSpec{
+				secret("Secrets", ".env", "Environment files commonly contain credentials and should stay local-only."),
+				secret("Secrets", ".env.local", "Local environment files commonly contain credentials and should stay local-only."),
+				secret("Secrets", ".npmrc", "npm config can contain registry tokens."),
+				secret("Secrets", ".netrc", "netrc files contain machine credentials."),
+				secret("Secrets", ".pypirc", "Python package registry config can contain publish tokens."),
+				secret("Secrets", ".git-credentials", "Git credential files must not be committed or synced."),
+				secret("Secrets", ".ssh", "SSH keys and config are machine-local credential material."),
+				secret("Secrets", ".aws", "AWS credentials and profiles are machine-local credential material."),
+				secret("Secrets", ".config/gh/hosts.yml", "GitHub CLI host tokens are machine-local credential material."),
+				secret("Secrets", ".docker/config.json", "Docker client config can contain registry tokens."),
 			},
 		},
 	}

--- a/internal/inventory/scanner_test.go
+++ b/internal/inventory/scanner_test.go
@@ -204,6 +204,42 @@ func TestScannerDoesNotWriteToHome(t *testing.T) {
 	}
 }
 
+func TestWorkspaceScannerFindsRepoAIConfigAndSecrets(t *testing.T) {
+	workspace := t.TempDir()
+	writeFile(t, filepath.Join(workspace, ".cursor", "mcp.json"), `{
+  "mcpServers": {
+    "local": {
+      "url": "http://127.0.0.1:8787/mcp",
+      "headers": {
+        "Authorization": "${MCP_TOKEN}"
+      }
+    }
+  }
+}`)
+	writeFile(t, filepath.Join(workspace, ".env"), "TOKEN=super-secret-value\n")
+
+	scanner := NewWorkspaceScanner(workspace)
+	scanner.Now = func() time.Time { return time.Date(2026, 4, 30, 7, 0, 0, 0, time.UTC) }
+	report := scanner.Scan()
+
+	if report.ScanMode != "workspace" || report.Workspace != workspace {
+		t.Fatalf("unexpected workspace report metadata: %#v", report)
+	}
+	if report.Summary.ItemsByClassification[SecretAuth] != 1 {
+		t.Fatalf("expected secret workspace item, got %#v", report.Summary.ItemsByClassification)
+	}
+	if report.Summary.FindingsByRule["mcp_local_endpoint"] != 1 || report.Summary.FindingsByRule["mcp_secret_header"] != 1 {
+		t.Fatalf("expected URL/header MCP findings, got %#v", report.Summary.FindingsByRule)
+	}
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "super-secret-value") {
+		t.Fatal("workspace scan leaked .env contents")
+	}
+}
+
 func TestScannerFindsExpandedAdaptersWithConservativeClassifications(t *testing.T) {
 	home := t.TempDir()
 	writeFile(t, filepath.Join(home, ".config", "zed", "settings.json"), `{}`)

--- a/internal/inventory/scanner_test.go
+++ b/internal/inventory/scanner_test.go
@@ -30,6 +30,15 @@ GITHUB_TOKEN = "${GITHUB_TOKEN}"
 	if report.Summary.TotalItems != 1 {
 		t.Fatalf("expected 1 item, got %d", report.Summary.TotalItems)
 	}
+	if report.Summary.ItemsByClassification[Portable] != 1 {
+		t.Fatalf("expected portable item summary, got %#v", report.Summary.ItemsByClassification)
+	}
+	if report.Summary.FindingsByRule["mcp_secret_env"] != 2 {
+		t.Fatalf("expected finding rule summary, got %#v", report.Summary.FindingsByRule)
+	}
+	if report.Summary.FindingsBySeverity[RiskCritical] != 1 || report.Summary.FindingsBySeverity[RiskMedium] < 1 {
+		t.Fatalf("expected finding severity summary, got %#v", report.Summary.FindingsBySeverity)
+	}
 	if report.Items[0].Classification != Portable {
 		t.Fatalf("expected portable Codex config, got %s", report.Items[0].Classification)
 	}
@@ -71,6 +80,86 @@ GITHUB_TOKEN = "${GITHUB_TOKEN}"
 	}
 	if strings.Contains(string(data), "super-secret-value") {
 		t.Fatal("scan report leaked an env secret value")
+	}
+}
+
+func TestScannerHandlesRemoteURLMCPShapesAndHeaders(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".codex", "config.toml"), `
+[mcp_servers.remote]
+url = "https://mcp.example.test/sse"
+
+[mcp_servers.local]
+url = "http://127.0.0.1:8787/mcp"
+
+[mcp_servers.header]
+type = "sse"
+url = "https://headers.example.test/mcp"
+
+[mcp_servers.header.headers]
+Authorization = "Bearer super-header-secret"
+X-API-Key = "${MCP_API_KEY}"
+
+[mcp_servers.unknown]
+type = "custom"
+`)
+	writeFile(t, filepath.Join(home, ".claude.json"), `{
+  "mcpServers": {
+    "context7": {
+      "type": "sse",
+      "url": "https://context.example.test/mcp",
+      "headers": {
+        "Authorization": "${CONTEXT_TOKEN}"
+      }
+    }
+  }
+}`)
+	writeFile(t, filepath.Join(home, ".cursor", "mcp.json"), `{
+  "mcpServers": {
+    "socket-mcp": {
+      "type": "streamable-http",
+      "url": "https://socket.example.test/mcp"
+    }
+  }
+}`)
+
+	report := NewScanner(home).Scan()
+	ruleCounts := map[string]int{}
+	for _, finding := range report.Findings {
+		ruleCounts[finding.Rule]++
+		if finding.Server != "unknown" && strings.Contains(finding.Evidence, "super-header-secret") {
+			t.Fatalf("finding leaked header value: %#v", finding)
+		}
+		if finding.Rule == "mcp_unknown_command" && finding.Server != "unknown" {
+			t.Fatalf("URL-shaped server produced unknown-command finding: %#v", finding)
+		}
+	}
+
+	if ruleCounts["mcp_secret_header"] != 3 {
+		t.Fatalf("expected three header findings, got %#v", ruleCounts)
+	}
+	if ruleCounts["mcp_local_endpoint"] != 1 {
+		t.Fatalf("expected one local endpoint finding, got %#v", ruleCounts)
+	}
+	if ruleCounts["mcp_unknown_command"] != 1 {
+		t.Fatalf("expected only malformed server to be unknown, got %#v", ruleCounts)
+	}
+	if report.Summary.FindingsByRule["mcp_secret_header"] != 3 || report.Summary.FindingsByTool["Codex"] == 0 {
+		t.Fatalf("summary did not include new finding buckets: %#v", report.Summary)
+	}
+
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	if strings.Contains(text, "super-header-secret") {
+		t.Fatalf("scan report leaked header value: %s", text)
+	}
+	for _, want := range []string{"mcp_secret_header", "header_key=Authorization", "transport=remote-url", "url=https://mcp.example.test"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("scan report missing %q: %s", want, text)
+		}
 	}
 }
 

--- a/internal/inventory/testdata/golden/scan-summary.golden.json
+++ b/internal/inventory/testdata/golden/scan-summary.golden.json
@@ -1,0 +1,27 @@
+{
+  "total_items": 1,
+  "total_findings": 8,
+  "items_by_classification": {
+    "portable": 1
+  },
+  "items_by_risk": {
+    "low": 1
+  },
+  "items_by_tool": {
+    "Codex": 1
+  },
+  "findings_by_severity": {
+    "critical": 1,
+    "info": 4,
+    "medium": 3
+  },
+  "findings_by_rule": {
+    "mcp_local_endpoint": 1,
+    "mcp_secret_header": 2,
+    "mcp_server_review": 4,
+    "mcp_unknown_command": 1
+  },
+  "findings_by_tool": {
+    "Codex": 8
+  }
+}

--- a/internal/inventory/testdata/golden/url-findings.golden.json
+++ b/internal/inventory/testdata/golden/url-findings.golden.json
@@ -1,0 +1,203 @@
+[
+  {
+    "id": "mcp_secret_header-bcdb8f0837fd",
+    "tool": "Codex",
+    "path": "/tmp/nightward-golden-home/.codex/config.toml",
+    "server": "header",
+    "severity": "critical",
+    "rule": "mcp_secret_header",
+    "message": "MCP server \"header\" stores a sensitive header.",
+    "evidence": "header_key=Authorization",
+    "recommended_action": "Keep sensitive header values outside dotfiles and document required header names only.",
+    "impact": "Credential-bearing headers in agent config can leak through dotfiles, backups, screenshots, or support bundles.",
+    "why_this_matters": "Remote MCP servers often use headers for authentication, so values should stay in dedicated local secret stores.",
+    "fix_available": true,
+    "fix_kind": "externalize-secret",
+    "confidence": "high",
+    "risk": "high",
+    "requires_review": true,
+    "fix_summary": "Move the Authorization header value out of this config and into a local secret source.",
+    "fix_steps": [
+      "Remove the inline value for the Authorization header from the MCP config.",
+      "Set AUTHORIZATION in your shell profile, launchd environment, password manager CLI, or another local secret source.",
+      "Keep only the header name or documented local setup prerequisite in portable dotfiles."
+    ],
+    "patch_hint": {
+      "kind": "externalize-secret",
+      "env_key": "AUTHORIZATION",
+      "inline_secret": true
+    }
+  },
+  {
+    "id": "mcp_secret_header-eba7e3966510",
+    "tool": "Codex",
+    "path": "/tmp/nightward-golden-home/.codex/config.toml",
+    "server": "header",
+    "severity": "medium",
+    "rule": "mcp_secret_header",
+    "message": "MCP server \"header\" references a sensitive header.",
+    "evidence": "header_key=X-API-Key",
+    "recommended_action": "Keep sensitive header values outside dotfiles and document required header names only.",
+    "impact": "Credential-bearing headers in agent config can leak through dotfiles, backups, screenshots, or support bundles.",
+    "why_this_matters": "Remote MCP servers often use headers for authentication, so values should stay in dedicated local secret stores.",
+    "fix_available": true,
+    "fix_kind": "externalize-secret",
+    "confidence": "medium",
+    "risk": "low",
+    "requires_review": true,
+    "fix_summary": "Document the X-API-Key header as a local prerequisite without committing its value.",
+    "fix_steps": [
+      "Confirm the X-API-Key header is only referenced by name or environment interpolation.",
+      "Document how to provide the secret locally without adding the value to dotfiles.",
+      "Keep the real value in a password manager, OS keychain, or machine-local env file excluded from Git."
+    ],
+    "patch_hint": {
+      "kind": "externalize-secret",
+      "env_key": "X_API_KEY"
+    }
+  },
+  {
+    "id": "mcp_local_endpoint-cf933c07a3ec",
+    "tool": "Codex",
+    "path": "/tmp/nightward-golden-home/.codex/config.toml",
+    "server": "local",
+    "severity": "medium",
+    "rule": "mcp_local_endpoint",
+    "message": "MCP server \"local\" points at a local or private endpoint.",
+    "evidence": "transport=remote-url type=unknown url=http://127.0.0.1:8787",
+    "recommended_action": "Keep local endpoint assumptions machine-local unless intentionally templated.",
+    "impact": "Local or private MCP endpoints may not exist on another machine and can reveal local network assumptions.",
+    "why_this_matters": "Portable dotfiles should distinguish remote service configuration from machine-local development endpoints.",
+    "fix_available": true,
+    "fix_kind": "manual-review",
+    "confidence": "medium",
+    "risk": "low",
+    "requires_review": true,
+    "fix_summary": "Move local endpoint assumptions into a machine-local overlay or document them as setup prerequisites.",
+    "fix_steps": [
+      "Confirm whether this MCP endpoint is intentionally machine-local.",
+      "Keep the URL in an ignored local overlay if it is not portable.",
+      "Document the expected local service when the endpoint is required for this machine."
+    ]
+  },
+  {
+    "id": "mcp_unknown_command-a5e74f7a7e1d",
+    "tool": "Codex",
+    "path": "/tmp/nightward-golden-home/.codex/config.toml",
+    "server": "unknown",
+    "severity": "medium",
+    "rule": "mcp_unknown_command",
+    "message": "MCP server \"unknown\" does not declare a command Nightward can inspect.",
+    "evidence": "keys=[type]",
+    "recommended_action": "Review this server manually before syncing.",
+    "impact": "Nightward cannot determine what executable would run for this MCP server.",
+    "why_this_matters": "Missing or unsupported server shapes block reliable policy checks and backup decisions.",
+    "fix_available": true,
+    "fix_kind": "manual-review",
+    "confidence": "high",
+    "risk": "low",
+    "requires_review": true,
+    "fix_summary": "Add a standard command field or open an adapter issue with a redacted config shape.",
+    "fix_steps": [
+      "Confirm whether the server uses a supported MCP config shape.",
+      "Add an explicit command field if the client supports it.",
+      "If the shape is valid but unsupported, file a Nightward adapter issue with secret values removed."
+    ]
+  },
+  {
+    "id": "mcp_server_review-d934e91f9921",
+    "tool": "Codex",
+    "path": "/tmp/nightward-golden-home/.codex/config.toml",
+    "server": "header",
+    "severity": "info",
+    "rule": "mcp_server_review",
+    "message": "Review MCP server \"header\" before syncing this config.",
+    "evidence": "transport=remote-url type=sse url=https://headers.example.test",
+    "recommended_action": "Confirm the server source, permissions, and local path assumptions.",
+    "impact": "This server may execute local code or expose local files when an AI client invokes it.",
+    "why_this_matters": "MCP configs are executable trust boundaries, so portable backups should preserve intent without hiding local-only risk.",
+    "fix_available": true,
+    "fix_kind": "ignore-with-reason",
+    "confidence": "medium",
+    "risk": "low",
+    "requires_review": true,
+    "fix_summary": "Keep the server only if its source, permissions, and local assumptions are understood.",
+    "fix_steps": [
+      "Identify the server package, binary, or script owner.",
+      "Confirm the command and arguments are expected for this machine.",
+      "Document why this server is safe to keep or exclude it from portable dotfiles."
+    ]
+  },
+  {
+    "id": "mcp_server_review-cf933c07a3ec",
+    "tool": "Codex",
+    "path": "/tmp/nightward-golden-home/.codex/config.toml",
+    "server": "local",
+    "severity": "info",
+    "rule": "mcp_server_review",
+    "message": "Review MCP server \"local\" before syncing this config.",
+    "evidence": "transport=remote-url type=unknown url=http://127.0.0.1:8787",
+    "recommended_action": "Confirm the server source, permissions, and local path assumptions.",
+    "impact": "This server may execute local code or expose local files when an AI client invokes it.",
+    "why_this_matters": "MCP configs are executable trust boundaries, so portable backups should preserve intent without hiding local-only risk.",
+    "fix_available": true,
+    "fix_kind": "ignore-with-reason",
+    "confidence": "medium",
+    "risk": "low",
+    "requires_review": true,
+    "fix_summary": "Keep the server only if its source, permissions, and local assumptions are understood.",
+    "fix_steps": [
+      "Identify the server package, binary, or script owner.",
+      "Confirm the command and arguments are expected for this machine.",
+      "Document why this server is safe to keep or exclude it from portable dotfiles."
+    ]
+  },
+  {
+    "id": "mcp_server_review-f17f9e7bd3e7",
+    "tool": "Codex",
+    "path": "/tmp/nightward-golden-home/.codex/config.toml",
+    "server": "remote",
+    "severity": "info",
+    "rule": "mcp_server_review",
+    "message": "Review MCP server \"remote\" before syncing this config.",
+    "evidence": "transport=remote-url type=unknown url=https://mcp.example.test",
+    "recommended_action": "Confirm the server source, permissions, and local path assumptions.",
+    "impact": "This server may execute local code or expose local files when an AI client invokes it.",
+    "why_this_matters": "MCP configs are executable trust boundaries, so portable backups should preserve intent without hiding local-only risk.",
+    "fix_available": true,
+    "fix_kind": "ignore-with-reason",
+    "confidence": "medium",
+    "risk": "low",
+    "requires_review": true,
+    "fix_summary": "Keep the server only if its source, permissions, and local assumptions are understood.",
+    "fix_steps": [
+      "Identify the server package, binary, or script owner.",
+      "Confirm the command and arguments are expected for this machine.",
+      "Document why this server is safe to keep or exclude it from portable dotfiles."
+    ]
+  },
+  {
+    "id": "mcp_server_review-a5e74f7a7e1d",
+    "tool": "Codex",
+    "path": "/tmp/nightward-golden-home/.codex/config.toml",
+    "server": "unknown",
+    "severity": "info",
+    "rule": "mcp_server_review",
+    "message": "Review MCP server \"unknown\" before syncing this config.",
+    "evidence": "command=unknown",
+    "recommended_action": "Confirm the server source, permissions, and local path assumptions.",
+    "impact": "This server may execute local code or expose local files when an AI client invokes it.",
+    "why_this_matters": "MCP configs are executable trust boundaries, so portable backups should preserve intent without hiding local-only risk.",
+    "fix_available": true,
+    "fix_kind": "ignore-with-reason",
+    "confidence": "medium",
+    "risk": "low",
+    "requires_review": true,
+    "fix_summary": "Keep the server only if its source, permissions, and local assumptions are understood.",
+    "fix_steps": [
+      "Identify the server package, binary, or script owner.",
+      "Confirm the command and arguments are expected for this machine.",
+      "Document why this server is safe to keep or exclude it from portable dotfiles."
+    ]
+  }
+]

--- a/internal/inventory/types.go
+++ b/internal/inventory/types.go
@@ -26,7 +26,8 @@ const (
 type FixKind string
 
 const (
-	FixPinPackage          FixKind = "pin-package"
+	FixPinPackage FixKind = "pin-package"
+	// #nosec G101 -- user-facing remediation kind name, not a credential.
 	FixExternalizeSecret   FixKind = "externalize-secret"
 	FixReplaceShellWrapper FixKind = "replace-shell-wrapper"
 	FixNarrowFilesystem    FixKind = "narrow-filesystem"

--- a/internal/inventory/types.go
+++ b/internal/inventory/types.go
@@ -104,6 +104,8 @@ type Report struct {
 	GeneratedAt time.Time       `json:"generated_at"`
 	Hostname    string          `json:"hostname"`
 	Home        string          `json:"home"`
+	Workspace   string          `json:"workspace,omitempty"`
+	ScanMode    string          `json:"scan_mode,omitempty"`
 	Summary     Summary         `json:"summary"`
 	Items       []Item          `json:"items"`
 	Findings    []Finding       `json:"findings"`

--- a/internal/inventory/types.go
+++ b/internal/inventory/types.go
@@ -90,11 +90,14 @@ type AdapterStatus struct {
 }
 
 type Summary struct {
-	TotalItems       int                    `json:"total_items"`
-	TotalFindings    int                    `json:"total_findings"`
-	ByClassification map[Classification]int `json:"by_classification"`
-	ByRisk           map[RiskLevel]int      `json:"by_risk"`
-	Tools            map[string]int         `json:"tools"`
+	TotalItems            int                    `json:"total_items"`
+	TotalFindings         int                    `json:"total_findings"`
+	ItemsByClassification map[Classification]int `json:"items_by_classification"`
+	ItemsByRisk           map[RiskLevel]int      `json:"items_by_risk"`
+	ItemsByTool           map[string]int         `json:"items_by_tool"`
+	FindingsBySeverity    map[RiskLevel]int      `json:"findings_by_severity"`
+	FindingsByRule        map[string]int         `json:"findings_by_rule"`
+	FindingsByTool        map[string]int         `json:"findings_by_tool"`
 }
 
 type Report struct {

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -11,30 +11,34 @@ import (
 	"strings"
 	"time"
 
-	"github.com/shadowbook/nightward/internal/inventory"
+	"github.com/jsonbored/nightward/internal/analysis"
+	"github.com/jsonbored/nightward/internal/inventory"
 	"gopkg.in/yaml.v3"
 )
 
 type Report struct {
-	GeneratedAt time.Time           `json:"generated_at"`
-	Strict      bool                `json:"strict"`
-	Passed      bool                `json:"passed"`
-	Threshold   inventory.RiskLevel `json:"threshold"`
-	ConfigPath  string              `json:"config_path,omitempty"`
-	Summary     Summary             `json:"summary"`
-	Violations  []inventory.Finding `json:"violations"`
-	Ignored     []IgnoredFinding    `json:"ignored,omitempty"`
+	GeneratedAt      time.Time           `json:"generated_at"`
+	Strict           bool                `json:"strict"`
+	Passed           bool                `json:"passed"`
+	Threshold        inventory.RiskLevel `json:"threshold"`
+	ConfigPath       string              `json:"config_path,omitempty"`
+	Summary          Summary             `json:"summary"`
+	Violations       []inventory.Finding `json:"violations"`
+	SignalViolations []analysis.Signal   `json:"signal_violations,omitempty"`
+	Ignored          []IgnoredFinding    `json:"ignored,omitempty"`
 }
 
 type Summary struct {
-	TotalFindings int `json:"total_findings"`
-	Violations    int `json:"violations"`
-	Ignored       int `json:"ignored"`
-	Critical      int `json:"critical"`
-	High          int `json:"high"`
-	Medium        int `json:"medium"`
-	Low           int `json:"low"`
-	Info          int `json:"info"`
+	TotalFindings    int `json:"total_findings"`
+	TotalSignals     int `json:"total_signals,omitempty"`
+	Violations       int `json:"violations"`
+	SignalViolations int `json:"signal_violations,omitempty"`
+	Ignored          int `json:"ignored"`
+	Critical         int `json:"critical"`
+	High             int `json:"high"`
+	Medium           int `json:"medium"`
+	Low              int `json:"low"`
+	Info             int `json:"info"`
 }
 
 type Config struct {
@@ -45,6 +49,10 @@ type Config struct {
 	TrustedPackages       []string            `json:"trusted_packages,omitempty" yaml:"trusted_packages"`
 	PortableAllowPaths    []string            `json:"portable_allow_paths,omitempty" yaml:"portable_allow_paths"`
 	MachineLocalDenyPaths []string            `json:"machine_local_deny_paths,omitempty" yaml:"machine_local_deny_paths"`
+	IncludeAnalysis       bool                `json:"include_analysis,omitempty" yaml:"include_analysis"`
+	AnalysisThreshold     inventory.RiskLevel `json:"analysis_threshold,omitempty" yaml:"analysis_threshold"`
+	AnalysisProviders     []string            `json:"analysis_providers,omitempty" yaml:"analysis_providers"`
+	AllowOnlineProviders  bool                `json:"allow_online_providers,omitempty" yaml:"allow_online_providers"`
 	SARIF                 SARIFConfig         `json:"sarif,omitempty" yaml:"sarif"`
 	path                  string
 }
@@ -72,9 +80,13 @@ type SARIFConfig struct {
 	SemanticVersion string `json:"semantic_version,omitempty" yaml:"semantic_version"`
 }
 
+const sarifAnalysisRulePrefix = "nightward/" + "analyze/"
+
 type Options struct {
-	Strict bool
-	Config Config
+	Strict          bool
+	Config          Config
+	IncludeAnalysis bool
+	Analysis        analysis.Report
 }
 
 func Check(report inventory.Report, strict bool) Report {
@@ -119,9 +131,22 @@ func CheckWithOptions(report inventory.Report, options Options) Report {
 			out.Violations = append(out.Violations, finding)
 		}
 	}
+	if options.IncludeAnalysis || options.Config.IncludeAnalysis {
+		analysisThreshold := threshold
+		if options.Config.AnalysisThreshold != "" {
+			analysisThreshold = options.Config.AnalysisThreshold
+		}
+		out.Summary.TotalSignals = len(options.Analysis.Signals)
+		for _, signal := range options.Analysis.Signals {
+			if riskRank(signal.Severity) >= riskRank(analysisThreshold) {
+				out.SignalViolations = append(out.SignalViolations, signal)
+			}
+		}
+		out.Summary.SignalViolations = len(out.SignalViolations)
+	}
 	out.Summary.Violations = len(out.Violations)
 	out.Summary.Ignored = len(out.Ignored)
-	out.Passed = len(out.Violations) == 0
+	out.Passed = len(out.Violations) == 0 && len(out.SignalViolations) == 0
 	return out
 }
 
@@ -131,6 +156,10 @@ func WriteSARIF(report inventory.Report, path string) error {
 
 func WriteSARIFWithConfig(report inventory.Report, path string, config Config) error {
 	sarif := BuildSARIFWithConfig(report, config)
+	return WriteSARIFObject(sarif, path)
+}
+
+func WriteSARIFObject(sarif map[string]any, path string) error {
 	data, err := json.MarshalIndent(sarif, "", "  ")
 	if err != nil {
 		return err
@@ -147,6 +176,10 @@ func BuildSARIF(report inventory.Report) map[string]any {
 }
 
 func BuildSARIFWithConfig(report inventory.Report, config Config) map[string]any {
+	return BuildSARIFWithAnalysis(report, analysis.Report{}, config)
+}
+
+func BuildSARIFWithAnalysis(report inventory.Report, analysisReport analysis.Report, config Config) map[string]any {
 	included := make([]inventory.Finding, 0, len(report.Findings))
 	for _, finding := range report.Findings {
 		if _, ignored := ignoreReason(finding, config); ignored {
@@ -155,9 +188,18 @@ func BuildSARIFWithConfig(report inventory.Report, config Config) map[string]any
 		included = append(included, finding)
 	}
 	rules := sarifRules(included)
+	if len(analysisReport.Signals) > 0 {
+		rules = append(rules, sarifSignalRules(analysisReport.Signals)...)
+		sort.Slice(rules, func(i, j int) bool {
+			return fmt.Sprint(rules[i]["id"]) < fmt.Sprint(rules[j]["id"])
+		})
+	}
 	results := make([]map[string]any, 0, len(included))
 	for _, finding := range included {
 		results = append(results, sarifResult(finding))
+	}
+	for _, signal := range analysisReport.Signals {
+		results = append(results, sarifSignalResult(signal))
 	}
 	name := config.SARIF.ToolName
 	if name == "" {
@@ -195,6 +237,7 @@ func BuildSARIFWithConfig(report inventory.Report, config Config) map[string]any
 func DefaultConfig() Config {
 	return Config{
 		SeverityThreshold: inventory.RiskHigh,
+		AnalysisThreshold: inventory.RiskHigh,
 		SARIF: SARIFConfig{
 			ToolName:        "Nightward",
 			Category:        "nightward",
@@ -225,6 +268,10 @@ Fields:
   trusted_packages: package names to suppress unpinned-package policy noise when evidence matches
   portable_allow_paths: reviewed portable path prefixes for future adapter policy
   machine_local_deny_paths: path prefixes that should remain local-only
+  include_analysis: include offline analysis signals in policy decisions
+  analysis_threshold: optional signal threshold when include_analysis is true
+  analysis_providers: optional provider names for future explicit provider analysis
+  allow_online_providers: allow selected network-capable providers when analysis_providers requests them
   sarif.tool_name: SARIF tool display name
   sarif.category: SARIF automation category
   sarif.information_uri: SARIF tool information URI
@@ -257,6 +304,9 @@ func LoadConfig(path string) (Config, error) {
 func ValidateConfig(config Config) error {
 	if config.SeverityThreshold != "" && !validRisk(config.SeverityThreshold) {
 		return fmt.Errorf("unsupported severity_threshold %q", config.SeverityThreshold)
+	}
+	if config.AnalysisThreshold != "" && !validRisk(config.AnalysisThreshold) {
+		return fmt.Errorf("unsupported analysis_threshold %q", config.AnalysisThreshold)
 	}
 	for _, entry := range config.IgnoreFindings {
 		if strings.TrimSpace(entry.ID) == "" {
@@ -316,6 +366,46 @@ func sarifRules(findings []inventory.Finding) []map[string]any {
 	return rules
 }
 
+func sarifSignalRules(signals []analysis.Signal) []map[string]any {
+	byRule := map[string]analysis.Signal{}
+	for _, signal := range signals {
+		ruleID := sarifAnalysisRulePrefix + strings.TrimPrefix(signal.Rule, "nightward/")
+		if _, ok := byRule[ruleID]; !ok {
+			byRule[ruleID] = signal
+		}
+	}
+	keys := make([]string, 0, len(byRule))
+	for key := range byRule {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	rules := make([]map[string]any, 0, len(keys))
+	for _, key := range keys {
+		signal := byRule[key]
+		rules = append(rules, map[string]any{
+			"id":   key,
+			"name": strings.ReplaceAll(strings.TrimPrefix(key, sarifAnalysisRulePrefix), "_", " "),
+			"shortDescription": map[string]string{
+				"text": signal.Message,
+			},
+			"fullDescription": map[string]string{
+				"text": signal.Why,
+			},
+			"help": map[string]any{
+				"text":     signal.Recommendation,
+				"markdown": signal.Recommendation,
+			},
+			"properties": map[string]any{
+				"severity":   signal.Severity,
+				"provider":   signal.Provider,
+				"category":   signal.Category,
+				"confidence": signal.Confidence,
+			},
+		})
+	}
+	return rules
+}
+
 func sarifResult(finding inventory.Finding) map[string]any {
 	return map[string]any{
 		"ruleId":  finding.Rule,
@@ -341,6 +431,39 @@ func sarifResult(finding inventory.Finding) map[string]any {
 			"fix_risk":        finding.Risk,
 			"confidence":      finding.Confidence,
 			"requires_review": finding.RequiresReview,
+		},
+	}
+}
+
+func sarifSignalResult(signal analysis.Signal) map[string]any {
+	path := "."
+	if signal.Path != "" {
+		path = signal.Path
+	}
+	ruleID := sarifAnalysisRulePrefix + strings.TrimPrefix(signal.Rule, "nightward/")
+	return map[string]any{
+		"ruleId":  ruleID,
+		"level":   sarifLevel(signal.Severity),
+		"message": map[string]string{"text": signal.Message},
+		"locations": []map[string]any{
+			{
+				"physicalLocation": map[string]any{
+					"artifactLocation": map[string]string{
+						"uri": artifactURI(path),
+					},
+				},
+			},
+		},
+		"properties": map[string]any{
+			"signal_id":          signal.ID,
+			"provider":           signal.Provider,
+			"category":           signal.Category,
+			"subject_id":         signal.SubjectID,
+			"subject_type":       signal.SubjectType,
+			"severity":           signal.Severity,
+			"confidence":         signal.Confidence,
+			"evidence":           signal.Evidence,
+			"recommended_action": signal.Recommendation,
 		},
 	}
 }

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -165,7 +165,9 @@ func WriteSARIFObject(sarif map[string]any, path string) error {
 		return err
 	}
 	data = append(data, '\n')
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil && filepath.Dir(path) != "." {
+	path = filepath.Clean(path)
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil && dir != "." {
 		return err
 	}
 	return os.WriteFile(path, data, 0600)
@@ -284,7 +286,7 @@ func LoadConfig(path string) (Config, error) {
 	if path == "" {
 		return Config{}, nil
 	}
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path)) // #nosec G304 -- policy config path is an explicit local CLI input.
 	if err != nil {
 		return Config{}, err
 	}

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -8,7 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shadowbook/nightward/internal/inventory"
+	"github.com/jsonbored/nightward/internal/analysis"
+	"github.com/jsonbored/nightward/internal/inventory"
 )
 
 func TestCheckUsesStrictThreshold(t *testing.T) {
@@ -139,6 +140,45 @@ func TestSARIFUsesConfigMetadataAndIgnores(t *testing.T) {
 	}
 	if strings.Contains(text, "ignored") {
 		t.Fatalf("SARIF included ignored finding: %s", text)
+	}
+}
+
+func TestPolicyCanIncludeAnalysisSignals(t *testing.T) {
+	report := inventory.Report{Findings: []inventory.Finding{
+		{ID: "review", Severity: inventory.RiskInfo, Rule: "mcp_server_review", Message: "review"},
+	}}
+	analysisReport := analysis.Report{Signals: []analysis.Signal{
+		{
+			ID:             "signal-1",
+			Provider:       "nightward",
+			Rule:           "nightward/secret_auth_path",
+			Category:       analysis.CategorySecrets,
+			SubjectID:      "item-1",
+			SubjectType:    analysis.SubjectItem,
+			Path:           "/tmp/workspace/.env",
+			Severity:       inventory.RiskCritical,
+			Confidence:     "high",
+			Message:        "Secret path present.",
+			Evidence:       "classification=secret-auth path=/tmp/workspace/.env",
+			Recommendation: "Exclude it.",
+		},
+	}}
+
+	checked := CheckWithOptions(report, Options{IncludeAnalysis: true, Analysis: analysisReport})
+	if checked.Passed || checked.Summary.SignalViolations != 1 || len(checked.SignalViolations) != 1 {
+		t.Fatalf("expected analysis signal policy violation: %#v", checked)
+	}
+
+	sarif := BuildSARIFWithAnalysis(report, analysisReport, Config{})
+	data, err := json.Marshal(sarif)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	for _, want := range []string{"nightward/analyze/secret_auth_path", "signal-1", ".env"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("SARIF missing analysis signal %q: %s", want, text)
+		}
 	}
 }
 

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -141,3 +141,77 @@ func TestSARIFUsesConfigMetadataAndIgnores(t *testing.T) {
 		t.Fatalf("SARIF included ignored finding: %s", text)
 	}
 }
+
+func TestGoldenSARIFForURLSecurityFindings(t *testing.T) {
+	report := inventory.Report{Findings: []inventory.Finding{
+		{
+			ID:             "mcp_secret_header-111111111111",
+			Tool:           "Codex",
+			Path:           "/tmp/nightward-golden-home/.codex/config.toml",
+			Server:         "headers",
+			Severity:       inventory.RiskCritical,
+			Rule:           "mcp_secret_header",
+			Message:        "MCP server \"headers\" stores a sensitive header.",
+			Evidence:       "header_key=Authorization",
+			Recommendation: "Keep sensitive header values outside dotfiles.",
+			Impact:         "Credential-bearing headers in agent config can leak.",
+			Why:            "Remote MCP servers often use headers for authentication.",
+			FixAvailable:   true,
+			FixKind:        inventory.FixExternalizeSecret,
+			Confidence:     "high",
+			Risk:           inventory.RiskHigh,
+			RequiresReview: true,
+			FixSummary:     "Move the Authorization header value out of this config.",
+			FixSteps:       []string{"Remove the inline value for the Authorization header."},
+		},
+		{
+			ID:             "mcp_local_endpoint-222222222222",
+			Tool:           "Cursor",
+			Path:           "/tmp/nightward-golden-home/.cursor/mcp.json",
+			Server:         "local",
+			Severity:       inventory.RiskMedium,
+			Rule:           "mcp_local_endpoint",
+			Message:        "MCP server \"local\" points at a local or private endpoint.",
+			Evidence:       "transport=remote-url type=unknown url=http://127.0.0.1:8787",
+			Recommendation: "Keep local endpoint assumptions machine-local unless intentionally templated.",
+			Impact:         "Local or private MCP endpoints may not exist on another machine.",
+			Why:            "Portable dotfiles should distinguish remote service configuration from machine-local development endpoints.",
+			FixAvailable:   true,
+			FixKind:        inventory.FixManualReview,
+			Confidence:     "medium",
+			Risk:           inventory.RiskLow,
+			RequiresReview: true,
+			FixSummary:     "Move local endpoint assumptions into a machine-local overlay.",
+			FixSteps:       []string{"Confirm whether this MCP endpoint is intentionally machine-local."},
+		},
+	}}
+
+	sarif := BuildSARIF(report)
+	assertGoldenPolicyJSON(t, "testdata/golden/url-security.sarif.golden.json", sarif)
+	data, err := json.Marshal(sarif)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	for _, leaked := range []string{"super-header-secret", "Bearer "} {
+		if strings.Contains(text, leaked) {
+			t.Fatalf("SARIF leaked secret value %q: %s", leaked, text)
+		}
+	}
+}
+
+func assertGoldenPolicyJSON(t *testing.T, path string, value any) {
+	t.Helper()
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual := string(data) + "\n"
+	expected, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read golden %s: %v\nactual:\n%s", path, err, actual)
+	}
+	if string(expected) != actual {
+		t.Fatalf("golden mismatch for %s\nexpected:\n%s\nactual:\n%s", path, expected, actual)
+	}
+}

--- a/internal/policy/testdata/golden/url-security.sarif.golden.json
+++ b/internal/policy/testdata/golden/url-security.sarif.golden.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "runs": [
+    {
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "/tmp/nightward-golden-home/.codex/config.toml"
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "MCP server \"headers\" stores a sensitive header."
+          },
+          "properties": {
+            "confidence": "high",
+            "evidence": "header_key=Authorization",
+            "finding_id": "mcp_secret_header-111111111111",
+            "fix_kind": "externalize-secret",
+            "fix_risk": "high",
+            "fix_steps": [
+              "Remove the inline value for the Authorization header."
+            ],
+            "recommended_fix": "Move the Authorization header value out of this config.",
+            "requires_review": true,
+            "severity": "critical",
+            "tool": "Codex"
+          },
+          "ruleId": "mcp_secret_header"
+        },
+        {
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "/tmp/nightward-golden-home/.cursor/mcp.json"
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "MCP server \"local\" points at a local or private endpoint."
+          },
+          "properties": {
+            "confidence": "medium",
+            "evidence": "transport=remote-url type=unknown url=http://127.0.0.1:8787",
+            "finding_id": "mcp_local_endpoint-222222222222",
+            "fix_kind": "manual-review",
+            "fix_risk": "low",
+            "fix_steps": [
+              "Confirm whether this MCP endpoint is intentionally machine-local."
+            ],
+            "recommended_fix": "Move local endpoint assumptions into a machine-local overlay.",
+            "requires_review": true,
+            "severity": "medium",
+            "tool": "Cursor"
+          },
+          "ruleId": "mcp_local_endpoint"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/JSONbored/nightward",
+          "name": "Nightward",
+          "rules": [
+            {
+              "fullDescription": {
+                "text": "Portable dotfiles should distinguish remote service configuration from machine-local development endpoints."
+              },
+              "help": {
+                "markdown": "Move local endpoint assumptions into a machine-local overlay.",
+                "text": "Keep local endpoint assumptions machine-local unless intentionally templated."
+              },
+              "id": "mcp_local_endpoint",
+              "name": "mcp local endpoint",
+              "properties": {
+                "fix_available": true,
+                "fix_kind": "manual-review",
+                "requires_review": true,
+                "severity": "medium"
+              },
+              "shortDescription": {
+                "text": "MCP server \"local\" points at a local or private endpoint."
+              }
+            },
+            {
+              "fullDescription": {
+                "text": "Remote MCP servers often use headers for authentication."
+              },
+              "help": {
+                "markdown": "Move the Authorization header value out of this config.",
+                "text": "Keep sensitive header values outside dotfiles."
+              },
+              "id": "mcp_secret_header",
+              "name": "mcp secret header",
+              "properties": {
+                "fix_available": true,
+                "fix_kind": "externalize-secret",
+                "requires_review": true,
+                "severity": "critical"
+              },
+              "shortDescription": {
+                "text": "MCP server \"headers\" stores a sensitive header."
+              }
+            }
+          ],
+          "semanticVersion": "0.1.0"
+        }
+      }
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/internal/schedule/schedule.go
+++ b/internal/schedule/schedule.go
@@ -116,14 +116,14 @@ func Install(home, executable, preset string) (Plan, error) {
 	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
 		return plan, errors.New("automatic schedule install is only supported for launchd and systemd user timers in v1")
 	}
-	if err := os.MkdirAll(plan.ReportDir, 0755); err != nil {
+	if err := os.MkdirAll(plan.ReportDir, 0700); err != nil {
 		return plan, err
 	}
-	if err := os.MkdirAll(plan.LogDir, 0755); err != nil {
+	if err := os.MkdirAll(plan.LogDir, 0700); err != nil {
 		return plan, err
 	}
 	for _, file := range plan.Files {
-		if err := os.MkdirAll(filepath.Dir(file.Path), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(file.Path), 0700); err != nil {
 			return plan, err
 		}
 		if err := os.WriteFile(file.Path, []byte(file.Content), os.FileMode(file.Mode)); err != nil {
@@ -132,8 +132,8 @@ func Install(home, executable, preset string) (Plan, error) {
 	}
 	if runtime.GOOS == "darwin" {
 		uid := strconv.Itoa(os.Getuid())
-		_ = exec.Command("launchctl", "bootout", "gui/"+uid, plan.Files[0].Path).Run()
-		if err := exec.Command("launchctl", "bootstrap", "gui/"+uid, plan.Files[0].Path).Run(); err != nil {
+		_ = exec.Command("launchctl", "bootout", "gui/"+uid, plan.Files[0].Path).Run()                       // #nosec G204 -- fixed system command, generated user LaunchAgent path, no shell.
+		if err := exec.Command("launchctl", "bootstrap", "gui/"+uid, plan.Files[0].Path).Run(); err != nil { // #nosec G204 -- fixed system command, generated user LaunchAgent path, no shell.
 			return plan, fmt.Errorf("wrote launchd plist but failed to bootstrap: %w", err)
 		}
 	} else if runtime.GOOS == "linux" {
@@ -152,7 +152,7 @@ func Remove(home string) (Plan, error) {
 	case "darwin":
 		path := filepath.Join(home, "Library", "LaunchAgents", Label+".plist")
 		uid := strconv.Itoa(os.Getuid())
-		_ = exec.Command("launchctl", "bootout", "gui/"+uid, path).Run()
+		_ = exec.Command("launchctl", "bootout", "gui/"+uid, path).Run() // #nosec G204 -- fixed system command, generated user LaunchAgent path, no shell.
 		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return plan, err
 		}
@@ -265,7 +265,7 @@ func lastReport(reportDir string) (string, *time.Time, int) {
 	var newest os.FileInfo
 	var newestPath string
 	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+		if entry.IsDir() || entry.Type()&os.ModeSymlink != 0 || !strings.HasSuffix(entry.Name(), ".json") {
 			continue
 		}
 		info, err := entry.Info()
@@ -285,7 +285,7 @@ func lastReport(reportDir string) (string, *time.Time, int) {
 }
 
 func countFindings(path string) int {
-	contents, err := os.ReadFile(path)
+	contents, err := os.ReadFile(filepath.Clean(path)) // #nosec G304 -- path is selected from the private Nightward report directory.
 	if err != nil {
 		return 0
 	}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -6,8 +6,8 @@ import (
 	"sort"
 	"time"
 
-	"github.com/shadowbook/nightward/internal/backupplan"
-	"github.com/shadowbook/nightward/internal/inventory"
+	"github.com/jsonbored/nightward/internal/backupplan"
+	"github.com/jsonbored/nightward/internal/inventory"
 )
 
 type Plan struct {

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -3,6 +3,7 @@ package snapshot
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"sort"
 	"time"
 
@@ -82,7 +83,7 @@ func Build(report inventory.Report, targetRoot string) Plan {
 }
 
 func Load(path string) (Plan, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path)) // #nosec G304 -- snapshot path is an explicit local CLI input for diff planning.
 	if err != nil {
 		return Plan{}, err
 	}

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shadowbook/nightward/internal/backupplan"
-	"github.com/shadowbook/nightward/internal/inventory"
+	"github.com/jsonbored/nightward/internal/backupplan"
+	"github.com/jsonbored/nightward/internal/inventory"
 )
 
 func TestBuildCreatesReadOnlySnapshotPlan(t *testing.T) {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -269,8 +269,14 @@ func (m model) dashboard(width int) string {
 		section("Classifications"),
 	}
 	for _, class := range []inventory.Classification{inventory.Portable, inventory.MachineLocal, inventory.SecretAuth, inventory.RuntimeCache, inventory.AppOwned, inventory.Unknown} {
-		if count := m.report.Summary.ByClassification[class]; count > 0 {
+		if count := m.report.Summary.ItemsByClassification[class]; count > 0 {
 			lines = append(lines, fmt.Sprintf("%-14s %d", class, count))
+		}
+	}
+	lines = append(lines, "", section("Finding Severity"))
+	for _, risk := range []inventory.RiskLevel{inventory.RiskCritical, inventory.RiskHigh, inventory.RiskMedium, inventory.RiskLow, inventory.RiskInfo} {
+		if count := m.report.Summary.FindingsBySeverity[risk]; count > 0 {
+			lines = append(lines, fmt.Sprintf("%-14s %d", risk, count))
 		}
 	}
 	lines = append(lines, "", section("Schedule"))

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -709,11 +709,11 @@ func clipboardCommandFor(goos, value string, lookPath func(string) (string, erro
 		cmd = exec.Command("pbcopy")
 	case "linux":
 		if path, err := lookPath("wl-copy"); err == nil {
-			cmd = exec.Command(path)
+			cmd = exec.Command(path) // #nosec G204 -- clipboard helper resolved by PATH and invoked without a shell.
 		} else if path, err := lookPath("xclip"); err == nil {
-			cmd = exec.Command(path, "-selection", "clipboard")
+			cmd = exec.Command(path, "-selection", "clipboard") // #nosec G204 -- clipboard helper resolved by PATH and invoked without a shell.
 		} else if path, err := lookPath("xsel"); err == nil {
-			cmd = exec.Command(path, "--clipboard", "--input")
+			cmd = exec.Command(path, "--clipboard", "--input") // #nosec G204 -- clipboard helper resolved by PATH and invoked without a shell.
 		} else {
 			return nil, errors.New("no clipboard command found: install wl-copy, xclip, or xsel")
 		}
@@ -740,11 +740,11 @@ func openURLCommandFor(goos, target string) (*exec.Cmd, error) {
 	}
 	switch goos {
 	case "darwin":
-		return exec.Command("open", target), nil
+		return exec.Command("open", target), nil // #nosec G204 -- validated http(s) documentation URL, invoked without a shell.
 	case "linux":
-		return exec.Command("xdg-open", target), nil
+		return exec.Command("xdg-open", target), nil // #nosec G204 -- validated http(s) documentation URL, invoked without a shell.
 	case "windows":
-		return exec.Command("rundll32", "url.dll,FileProtocolHandler", target), nil
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", target), nil // #nosec G204 -- validated http(s) documentation URL, invoked without a shell.
 	default:
 		return nil, fmt.Errorf("opening URLs unsupported on %s", goos)
 	}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1,9 +1,16 @@
 package tui
 
 import (
+	"errors"
 	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
 	"path/filepath"
+	"regexp"
+	"runtime"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -27,6 +34,10 @@ type model struct {
 	status    string
 	searching bool
 	showHelp  bool
+}
+
+type actionMsg struct {
+	status string
 }
 
 var (
@@ -64,6 +75,11 @@ var (
 
 var tabs = []string{"Dashboard", "Inventory", "Findings", "Fix Plan", "Backup Plan"}
 
+const remediationDocsURL = "https://github.com/JSONbored/nightward/blob/main/docs/remediation.md"
+
+var tuiSecretAssignmentPattern = regexp.MustCompile(`(?i)((?:token|secret|password|passwd|api[_-]?key|auth|credential|private[_-]?key)[\w.-]*\s*[:=]\s*)(["']?)[^"',\s}]+`)
+var tuiLongSecretPattern = regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{12,}\b`)
+
 func Run(report inventory.Report, scheduleStatus schedule.Plan) error {
 	_, err := tea.NewProgram(model{report: report, schedule: scheduleStatus}, tea.WithAltScreen()).Run()
 	return err
@@ -78,6 +94,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+	case actionMsg:
+		m.status = msg.status
 	case tea.KeyMsg:
 		if m.searching {
 			switch msg.String() {
@@ -156,17 +174,24 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.status = "filters cleared"
 			}
 		case "c":
-			if finding, ok := m.currentFinding(); ok && len(finding.FixSteps) > 0 {
-				m.status = "copy: " + finding.FixSteps[0]
+			value, label, ok := m.copySelection()
+			if !ok {
+				m.status = "copy: nothing selected"
+				return m, nil
 			}
+			m.status = "copying " + label + "..."
+			return m, copyToClipboardCmd(value, label)
 		case "e":
-			m.status = "export: nw fix export --format markdown"
+			m.status = "exporting fix plan..."
+			return m, exportFixPlanCmd(m.report)
 		case "o":
-			if finding, ok := m.currentFinding(); ok && finding.DocsURL != "" {
-				m.status = "open docs: " + finding.DocsURL
-			} else {
-				m.status = "open docs: no docs URL for selected finding"
+			docsURL, ok := m.currentDocsURL()
+			if !ok {
+				m.status = "open docs: no docs URL for selected row"
+				return m, nil
 			}
+			m.status = "opening docs..."
+			return m, openURLCmd(docsURL)
 		case "up", "k":
 			if m.cursor > 0 {
 				m.cursor--
@@ -192,7 +217,7 @@ func (m model) View() string {
 		bodyText = m.help(bodyWidth - 6)
 	}
 	body := panelStyle.Width(bodyWidth).Height(bodyHeight).Render(bodyText)
-	footerText := "1-5 tabs  arrows/hjkl navigate  / search  s/t/r filters  x clear  ? help  q quit"
+	footerText := "1-5 tabs  arrows/hjkl navigate  / search  s/t/r filters  x clear  c copy  e export  o docs  ? help  q quit"
 	if m.searching {
 		footerText = "search: " + m.search
 	}
@@ -413,9 +438,9 @@ func (m model) help(width int) string {
 		"s/t/r: cycle severity, tool, and rule filters in Findings",
 		"/: search findings",
 		"x: clear finding filters",
-		"c: show first suggested command or step for selected finding",
-		"e: show export command for fix plan",
-		"o: show docs URL for selected finding",
+		"c: copy selected path, recommendation, or fix step to clipboard",
+		"e: export a redacted fix plan to ~/.local/state/nightward/exports",
+		"o: open docs URL for the selected finding or fix",
 		"?: toggle this help",
 		"q or esc: quit",
 		"",
@@ -434,6 +459,114 @@ func (m model) currentFinding() (inventory.Finding, bool) {
 		cursor = len(findings) - 1
 	}
 	return findings[cursor], true
+}
+
+func (m model) currentItem() (inventory.Item, bool) {
+	if len(m.report.Items) == 0 {
+		return inventory.Item{}, false
+	}
+	cursor := m.cursor
+	if cursor >= len(m.report.Items) {
+		cursor = len(m.report.Items) - 1
+	}
+	return m.report.Items[cursor], true
+}
+
+func (m model) currentFix() (fixplan.Fix, bool) {
+	plan := fixplan.Build(m.report, fixplan.Selector{All: true})
+	if len(plan.Fixes) == 0 {
+		return fixplan.Fix{}, false
+	}
+	cursor := m.cursor
+	if cursor >= len(plan.Fixes) {
+		cursor = len(plan.Fixes) - 1
+	}
+	return plan.Fixes[cursor], true
+}
+
+func (m model) currentBackupEntry() (backupplan.Entry, bool) {
+	plan := backupplan.Build(m.report, filepath.Join(m.report.Home, "dotfiles"))
+	if len(plan.Entries) == 0 {
+		return backupplan.Entry{}, false
+	}
+	cursor := m.cursor
+	if cursor >= len(plan.Entries) {
+		cursor = len(plan.Entries) - 1
+	}
+	return plan.Entries[cursor], true
+}
+
+func (m model) copySelection() (string, string, bool) {
+	switch m.tab {
+	case 0:
+		if m.schedule.ReportDir != "" {
+			return m.schedule.ReportDir, "report path", true
+		}
+	case 1:
+		if item, ok := m.currentItem(); ok {
+			return item.Path, "path", true
+		}
+	case 2:
+		if finding, ok := m.currentFinding(); ok {
+			return findingCopyText(finding), "finding action", true
+		}
+	case 3:
+		if fix, ok := m.currentFix(); ok {
+			return fixCopyText(fix), "fix step", true
+		}
+	case 4:
+		if entry, ok := m.currentBackupEntry(); ok {
+			return entry.Source, "backup source path", true
+		}
+	}
+	return "", "", false
+}
+
+func (m model) currentDocsURL() (string, bool) {
+	switch m.tab {
+	case 2:
+		if finding, ok := m.currentFinding(); ok {
+			if finding.DocsURL != "" {
+				return finding.DocsURL, true
+			}
+			return ruleDocsURL(finding.Rule), true
+		}
+	case 3:
+		if fix, ok := m.currentFix(); ok && fix.Rule != "" {
+			return ruleDocsURL(fix.Rule), true
+		}
+	}
+	return "", false
+}
+
+func ruleDocsURL(rule string) string {
+	if rule == "" {
+		return remediationDocsURL
+	}
+	return remediationDocsURL + "#" + url.QueryEscape(strings.ToLower(rule))
+}
+
+func findingCopyText(finding inventory.Finding) string {
+	if len(finding.FixSteps) > 0 {
+		return redactTUIText(finding.FixSteps[0])
+	}
+	if finding.Recommendation != "" {
+		return redactTUIText(finding.Recommendation)
+	}
+	if finding.Evidence != "" {
+		return redactTUIText(finding.Evidence)
+	}
+	return finding.Path
+}
+
+func fixCopyText(fix fixplan.Fix) string {
+	if len(fix.Steps) > 0 {
+		return redactTUIText(fix.Steps[0])
+	}
+	if fix.Summary != "" {
+		return redactTUIText(fix.Summary)
+	}
+	return fix.Path
 }
 
 func findingDetail(finding inventory.Finding, width, height int) string {
@@ -463,6 +596,123 @@ func findingDetail(finding inventory.Finding, width, height int) string {
 		lines = lines[:height]
 	}
 	return fitLines(lines, width)
+}
+
+func copyToClipboardCmd(value, label string) tea.Cmd {
+	value = redactTUIText(value)
+	cmd, err := clipboardCommand(value)
+	if err != nil {
+		return actionStatusCmd(fmt.Sprintf("copy failed: %v", err))
+	}
+	return runActionCommand(cmd, "copied "+label)
+}
+
+func openURLCmd(target string) tea.Cmd {
+	cmd, err := openURLCommand(target)
+	if err != nil {
+		return actionStatusCmd(fmt.Sprintf("open docs failed: %v", err))
+	}
+	return runActionCommand(cmd, "opened docs")
+}
+
+func exportFixPlanCmd(report inventory.Report) tea.Cmd {
+	return func() tea.Msg {
+		path, err := exportFixPlan(report, time.Now().UTC())
+		if err != nil {
+			return actionMsg{status: fmt.Sprintf("export failed: %v", err)}
+		}
+		return actionMsg{status: "exported fix plan: " + path}
+	}
+}
+
+func actionStatusCmd(status string) tea.Cmd {
+	return func() tea.Msg {
+		return actionMsg{status: status}
+	}
+}
+
+func runActionCommand(cmd *exec.Cmd, success string) tea.Cmd {
+	return tea.ExecProcess(cmd, func(err error) tea.Msg {
+		if err != nil {
+			return actionMsg{status: fmt.Sprintf("%s failed: %v", success, err)}
+		}
+		return actionMsg{status: success}
+	})
+}
+
+func clipboardCommand(value string) (*exec.Cmd, error) {
+	return clipboardCommandFor(runtime.GOOS, value, exec.LookPath)
+}
+
+func clipboardCommandFor(goos, value string, lookPath func(string) (string, error)) (*exec.Cmd, error) {
+	var cmd *exec.Cmd
+	switch goos {
+	case "darwin":
+		cmd = exec.Command("pbcopy")
+	case "linux":
+		if path, err := lookPath("wl-copy"); err == nil {
+			cmd = exec.Command(path)
+		} else if path, err := lookPath("xclip"); err == nil {
+			cmd = exec.Command(path, "-selection", "clipboard")
+		} else if path, err := lookPath("xsel"); err == nil {
+			cmd = exec.Command(path, "--clipboard", "--input")
+		} else {
+			return nil, errors.New("no clipboard command found: install wl-copy, xclip, or xsel")
+		}
+	case "windows":
+		cmd = exec.Command("clip")
+	default:
+		return nil, fmt.Errorf("clipboard unsupported on %s", goos)
+	}
+	cmd.Stdin = strings.NewReader(value)
+	return cmd, nil
+}
+
+func openURLCommand(target string) (*exec.Cmd, error) {
+	return openURLCommandFor(runtime.GOOS, target)
+}
+
+func openURLCommandFor(goos, target string) (*exec.Cmd, error) {
+	parsed, err := url.Parse(target)
+	if err != nil || parsed == nil || parsed.Host == "" {
+		return nil, fmt.Errorf("invalid URL %q", target)
+	}
+	if parsed.Scheme != "https" && parsed.Scheme != "http" {
+		return nil, fmt.Errorf("unsupported URL scheme %q", parsed.Scheme)
+	}
+	switch goos {
+	case "darwin":
+		return exec.Command("open", target), nil
+	case "linux":
+		return exec.Command("xdg-open", target), nil
+	case "windows":
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", target), nil
+	default:
+		return nil, fmt.Errorf("opening URLs unsupported on %s", goos)
+	}
+}
+
+func exportFixPlan(report inventory.Report, now time.Time) (string, error) {
+	if report.Home == "" {
+		return "", errors.New("home directory missing from report")
+	}
+	dir := filepath.Join(report.Home, ".local", "state", "nightward", "exports")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", err
+	}
+	plan := fixplan.Build(report, fixplan.Selector{All: true})
+	markdown := redactTUIText(fixplan.Markdown(plan))
+	name := "fix-plan-" + now.UTC().Format("20060102T150405Z") + ".md"
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(markdown), 0600); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func redactTUIText(value string) string {
+	value = tuiSecretAssignmentPattern.ReplaceAllString(value, "$1$2[redacted]")
+	return tuiLongSecretPattern.ReplaceAllString(value, "[redacted]")
 }
 
 func riskOptions(findings []inventory.Finding) []string {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -14,10 +14,11 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/shadowbook/nightward/internal/backupplan"
-	"github.com/shadowbook/nightward/internal/fixplan"
-	"github.com/shadowbook/nightward/internal/inventory"
-	"github.com/shadowbook/nightward/internal/schedule"
+	"github.com/jsonbored/nightward/internal/analysis"
+	"github.com/jsonbored/nightward/internal/backupplan"
+	"github.com/jsonbored/nightward/internal/fixplan"
+	"github.com/jsonbored/nightward/internal/inventory"
+	"github.com/jsonbored/nightward/internal/schedule"
 )
 
 type model struct {
@@ -73,9 +74,10 @@ var (
 			Padding(0, 1)
 )
 
-var tabs = []string{"Dashboard", "Inventory", "Findings", "Fix Plan", "Backup Plan"}
+var tabs = []string{"Dashboard", "Inventory", "Findings", "Analysis", "Fix Plan", "Backup Plan"}
 
 const remediationDocsURL = "https://github.com/JSONbored/nightward/blob/main/docs/remediation.md"
+const analysisDocsURL = "https://github.com/JSONbored/nightward/blob/main/docs/analysis.md"
 
 var tuiSecretAssignmentPattern = regexp.MustCompile(`(?i)((?:token|secret|password|passwd|api[_-]?key|auth|credential|private[_-]?key)[\w.-]*\s*[:=]\s*)(["']?)[^"',\s}]+`)
 var tuiLongSecretPattern = regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{12,}\b`)
@@ -144,6 +146,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.tab = 3
 		case "5":
 			m.tab = 4
+		case "6":
+			m.tab = 5
 		case "s":
 			if m.tab == 2 {
 				m.severity = cycle(m.severity, riskOptions(m.report.Findings))
@@ -217,7 +221,7 @@ func (m model) View() string {
 		bodyText = m.help(bodyWidth - 6)
 	}
 	body := panelStyle.Width(bodyWidth).Height(bodyHeight).Render(bodyText)
-	footerText := "1-5 tabs  arrows/hjkl navigate  / search  s/t/r filters  x clear  c copy  e export  o docs  ? help  q quit"
+	footerText := "1-6 tabs  arrows/hjkl navigate  / search  s/t/r filters  x clear  c copy  e export  o docs  ? help  q quit"
 	if m.searching {
 		footerText = "search: " + m.search
 	}
@@ -250,6 +254,8 @@ func (m model) renderBody(width, height int) string {
 	case 2:
 		return m.findings(width, height)
 	case 3:
+		return m.analysis(width, height)
+	case 4:
 		return m.fixPlan(width, height)
 	default:
 		return m.backupPlan(width, height)
@@ -377,6 +383,34 @@ func (m model) fixPlan(width, height int) string {
 	return fitLines(lines, width)
 }
 
+func (m model) analysis(width, height int) string {
+	report := analysis.Run(m.report, analysis.Options{Mode: m.report.ScanMode, Workspace: m.report.Workspace})
+	lines := []string{
+		section("Analysis"),
+		fmt.Sprintf("Signals: %d  Subjects: %d  Highest: %s  Provider warnings: %d", report.Summary.TotalSignals, report.Summary.TotalSubjects, report.Summary.HighestSeverity, report.Summary.ProviderWarnings),
+		"",
+	}
+	if len(report.Signals) == 0 {
+		lines = append(lines, "No known risky signals from enabled providers.")
+		return fitLines(lines, width)
+	}
+	visible := max(1, height-5)
+	if m.cursor >= len(report.Signals) {
+		m.cursor = len(report.Signals) - 1
+	}
+	start := clampCursor(m.cursor, len(report.Signals), visible)
+	for i := start; i < len(report.Signals) && len(lines) < visible+3; i++ {
+		signal := report.Signals[i]
+		prefix := "  "
+		if i == m.cursor {
+			prefix = "> "
+		}
+		lines = append(lines, fmt.Sprintf("%s%-8s %-30s %s", prefix, signal.Severity, signal.Rule, signal.Message))
+	}
+	lines = append(lines, "", "Use `nw analyze --all --json` or `nw providers doctor --json` for full details.")
+	return fitLines(lines, width)
+}
+
 func (m model) backupPlan(width, height int) string {
 	target := filepath.Join(m.report.Home, "dotfiles")
 	plan := backupplan.Build(m.report, target)
@@ -439,7 +473,7 @@ func findingMatchesSearch(finding inventory.Finding, query string) bool {
 func (m model) help(width int) string {
 	lines := []string{
 		section("Help"),
-		"1-5 or tab: switch tabs",
+		"1-6 or tab: switch tabs",
 		"arrows or h/j/k/l: navigate rows",
 		"s/t/r: cycle severity, tool, and rule filters in Findings",
 		"/: search findings",
@@ -453,6 +487,18 @@ func (m model) help(width int) string {
 		"Nightward TUI actions do not mutate agent configs.",
 	}
 	return fitLines(lines, width)
+}
+
+func (m model) currentSignal() (analysis.Signal, bool) {
+	report := analysis.Run(m.report, analysis.Options{Mode: m.report.ScanMode, Workspace: m.report.Workspace})
+	if len(report.Signals) == 0 {
+		return analysis.Signal{}, false
+	}
+	cursor := m.cursor
+	if cursor >= len(report.Signals) {
+		cursor = len(report.Signals) - 1
+	}
+	return report.Signals[cursor], true
 }
 
 func (m model) currentFinding() (inventory.Finding, bool) {
@@ -517,10 +563,14 @@ func (m model) copySelection() (string, string, bool) {
 			return findingCopyText(finding), "finding action", true
 		}
 	case 3:
+		if signal, ok := m.currentSignal(); ok {
+			return signal.Recommendation, "analysis recommendation", true
+		}
+	case 4:
 		if fix, ok := m.currentFix(); ok {
 			return fixCopyText(fix), "fix step", true
 		}
-	case 4:
+	case 5:
 		if entry, ok := m.currentBackupEntry(); ok {
 			return entry.Source, "backup source path", true
 		}
@@ -538,6 +588,8 @@ func (m model) currentDocsURL() (string, bool) {
 			return ruleDocsURL(finding.Rule), true
 		}
 	case 3:
+		return analysisDocsURL, true
+	case 4:
 		if fix, ok := m.currentFix(); ok && fix.Rule != "" {
 			return ruleDocsURL(fix.Rule), true
 		}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shadowbook/nightward/internal/inventory"
+	"github.com/jsonbored/nightward/internal/inventory"
 )
 
 func TestFindingsAndFixPlanViewsRenderRedactedDetails(t *testing.T) {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1,6 +1,9 @@
 package tui
 
 import (
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -61,5 +64,133 @@ func TestFindingSearchAndHelpRender(t *testing.T) {
 	help := m.help(90)
 	if !strings.Contains(help, "search findings") || !strings.Contains(help, "do not mutate") {
 		t.Fatalf("help text missing expected content:\n%s", help)
+	}
+	if strings.Contains(help, "show first suggested") {
+		t.Fatalf("help text contains stale action wording:\n%s", help)
+	}
+}
+
+func TestTUIActionSelectionAndDocsURL(t *testing.T) {
+	report := inventory.Report{
+		Home: "/tmp/nightward-home",
+		Items: []inventory.Item{
+			{Path: "/tmp/nightward-home/.codex/config.toml"},
+		},
+		Findings: []inventory.Finding{
+			{
+				ID:             "mcp_secret_env-111111111111",
+				Tool:           "Codex",
+				Path:           "/tmp/nightward-home/.codex/config.toml",
+				Severity:       inventory.RiskCritical,
+				Rule:           "mcp_secret_env",
+				Recommendation: "Move API_TOKEN into an environment variable.",
+				FixAvailable:   true,
+				FixKind:        inventory.FixExternalizeSecret,
+				RequiresReview: true,
+				FixSteps:       []string{"Remove API_TOKEN=super-" + "secret-value from the MCP config."},
+			},
+		},
+	}
+
+	inventoryModel := model{report: report, tab: 1}
+	if got, label, ok := inventoryModel.copySelection(); !ok || label != "path" || got != "/tmp/nightward-home/.codex/config.toml" {
+		t.Fatalf("unexpected inventory copy selection: got=%q label=%q ok=%t", got, label, ok)
+	}
+
+	findingModel := model{report: report, tab: 2}
+	got, label, ok := findingModel.copySelection()
+	if !ok || label != "finding action" || strings.Contains(got, "secret-value") || !strings.Contains(got, "[redacted]") {
+		t.Fatalf("unexpected finding copy selection: got=%q label=%q ok=%t", got, label, ok)
+	}
+	if docsURL, ok := findingModel.currentDocsURL(); !ok || docsURL != ruleDocsURL("mcp_secret_env") {
+		t.Fatalf("unexpected docs URL: %q ok=%t", docsURL, ok)
+	}
+}
+
+func TestExportFixPlanWritesRedactedMarkdown(t *testing.T) {
+	home := t.TempDir()
+	secretValue := "super-" + "secret-value"
+	report := inventory.Report{
+		GeneratedAt: time.Date(2026, 4, 30, 7, 0, 0, 0, time.UTC),
+		Home:        home,
+		Findings: []inventory.Finding{
+			{
+				ID:             "mcp_secret_env-111111111111",
+				Tool:           "Codex",
+				Path:           filepath.Join(home, ".codex", "config.toml"),
+				Severity:       inventory.RiskCritical,
+				Rule:           "mcp_secret_env",
+				Evidence:       "API_TOKEN=" + secretValue,
+				FixAvailable:   true,
+				FixKind:        inventory.FixExternalizeSecret,
+				Confidence:     "high",
+				Risk:           inventory.RiskHigh,
+				RequiresReview: true,
+				FixSummary:     "Move API_TOKEN=" + secretValue + " out of this config.",
+				FixSteps:       []string{"Remove API_TOKEN=" + secretValue + " from the MCP config."},
+			},
+		},
+	}
+
+	path, err := exportFixPlan(report, time.Date(2026, 4, 30, 12, 13, 14, 0, time.UTC))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(home, ".local", "state", "nightward", "exports", "fix-plan-20260430T121314Z.md"); path != want {
+		t.Fatalf("unexpected export path: %s", path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	if strings.Contains(text, secretValue) {
+		t.Fatalf("export leaked secret value:\n%s", text)
+	}
+	if !strings.Contains(text, filepath.Join(home, ".codex", "config.toml")) {
+		t.Fatalf("export redacted non-secret path:\n%s", text)
+	}
+	if !strings.Contains(text, "[redacted]") || !strings.Contains(text, "API_TOKEN") {
+		t.Fatalf("export missing redacted guidance:\n%s", text)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Fatalf("expected private export mode 0600, got %s", got)
+	}
+}
+
+func TestClipboardAndOpenCommandBuilders(t *testing.T) {
+	lookup := func(name string) (string, error) {
+		if name == "xclip" {
+			return "/usr/bin/xclip", nil
+		}
+		return "", os.ErrNotExist
+	}
+	cmd, err := clipboardCommandFor("linux", "copy me", lookup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cmd.Path != "/usr/bin/xclip" || strings.Join(cmd.Args[1:], " ") != "-selection clipboard" {
+		t.Fatalf("unexpected clipboard command: path=%s args=%v", cmd.Path, cmd.Args)
+	}
+	data, err := io.ReadAll(cmd.Stdin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "copy me" {
+		t.Fatalf("unexpected clipboard stdin: %q", data)
+	}
+	if _, err := openURLCommandFor("darwin", "file:///tmp/secret"); err == nil {
+		t.Fatal("expected non-http URL to be rejected")
+	}
+	openCmd, err := openURLCommandFor("darwin", remediationDocsURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(openCmd.Path) != "open" || openCmd.Args[len(openCmd.Args)-1] != remediationDocsURL {
+		t.Fatalf("unexpected open command: path=%s args=%v", openCmd.Path, openCmd.Args)
 	}
 }

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,0 +1,54 @@
+version: 0.1
+required_trunk_version: ">=1.25.0"
+runtimes:
+  enabled:
+    - go@1.25.9
+tools:
+  definitions:
+    - name: nightward
+      runtime: go
+      package: github.com/jsonbored/nightward/cmd/nw
+      shims: [nw]
+      known_good_version: 0.1.0
+lint:
+  definitions:
+    - name: nightward-policy
+      files: [ALL]
+      tools: [nightward]
+      main_tool: nightward
+      direct_configs:
+        - .nightward.yml
+        - .mcp.json
+        - mcp.json
+        - AGENTS.md
+      suggest_if: config_present
+      known_good_version: 0.1.0
+      commands:
+        - name: lint
+          output: sarif
+          run: nw policy sarif --workspace ${workspace} --output -
+          success_codes: [0]
+          read_output_from: stdout
+          batch: true
+          cache_results: false
+          is_security: true
+    - name: nightward-analyze
+      files: [ALL]
+      tools: [nightward]
+      main_tool: nightward
+      direct_configs:
+        - .nightward.yml
+        - .mcp.json
+        - mcp.json
+        - AGENTS.md
+      suggest_if: config_present
+      known_good_version: 0.1.0
+      commands:
+        - name: lint
+          output: sarif
+          run: nw policy sarif --workspace ${workspace} --include-analysis --output -
+          success_codes: [0]
+          read_output_from: stdout
+          batch: true
+          cache_results: false
+          is_security: true

--- a/renovate.json
+++ b/renovate.json
@@ -58,7 +58,7 @@
     {
       "customType": "regex",
       "description": "Update gotestsum used by Makefile JUnit test reports.",
-      "managerFilePatterns": ["/^Makefile$/"],
+      "fileMatch": ["^Makefile$"],
       "matchStrings": [
         "GOTESTSUM_VERSION\\s*\\?=\\s*(?<currentValue>v?\\d+\\.\\d+\\.\\d+)"
       ],
@@ -68,7 +68,7 @@
     {
       "customType": "regex",
       "description": "Update the GoReleaser binary version used by the release workflow.",
-      "managerFilePatterns": ["/^\\.github/workflows/release\\.yml$/"],
+      "fileMatch": ["^\\.github/workflows/release\\.yml$"],
       "matchStrings": ["version:\\s*(?<currentValue>v\\d+\\.\\d+\\.\\d+)"],
       "depNameTemplate": "goreleaser/goreleaser",
       "datasourceTemplate": "github-releases"
@@ -76,7 +76,7 @@
     {
       "customType": "regex",
       "description": "Update the Trunk plugin registry pin.",
-      "managerFilePatterns": ["/^\\.trunk/trunk\\.yaml$/"],
+      "fileMatch": ["^\\.trunk/trunk\\.yaml$"],
       "matchStrings": ["ref:\\s*(?<currentValue>v\\d+\\.\\d+\\.\\d+)"],
       "depNameTemplate": "trunk-io/plugins",
       "datasourceTemplate": "github-tags"

--- a/tools/normalize-go-junit/main.go
+++ b/tools/normalize-go-junit/main.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var (
+	testcasePattern = regexp.MustCompile(`<testcase\b([^>]*)>`)
+	attrPattern     = regexp.MustCompile(`\b(classname|name)="([^"]*)"`)
+	funcPattern     = regexp.MustCompile(`func\s+([A-Za-z0-9_]+)\s*\(`)
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintln(os.Stderr, "usage: normalize-go-junit <input> <output>")
+		os.Exit(2)
+	}
+
+	modulePath, err := moduleName("go.mod")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	inputPath := filepath.Clean(os.Args[1])
+	outputPath := filepath.Clean(os.Args[2])
+
+	input, err := os.ReadFile(inputPath) // #nosec G703 -- explicit local Makefile report input, not user-served content.
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	cache := map[string]string{}
+	output := testcasePattern.ReplaceAllStringFunc(string(input), func(tag string) string {
+		attrs := testcasePattern.FindStringSubmatch(tag)
+		if len(attrs) != 2 || strings.Contains(attrs[1], ` file=`) || strings.Contains(attrs[1], ` filepath=`) {
+			return tag
+		}
+
+		className, testName := testcaseAttrs(attrs[1])
+		if className == "" || testName == "" {
+			return tag
+		}
+
+		file := testFileFor(modulePath, className, testName, cache)
+		if file == "" {
+			return tag
+		}
+		return strings.TrimSuffix(tag, ">") + ` file="` + escapeAttr(file) + `">`
+	})
+
+	if err := os.WriteFile(outputPath, []byte(output), 0600); err != nil { // #nosec G703 -- explicit local Makefile report output with private permissions.
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func moduleName(path string) (string, error) {
+	data, err := os.ReadFile(path) // #nosec G304 -- fixed repository go.mod path for local report normalization.
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && fields[0] == "module" {
+			return fields[1], nil
+		}
+	}
+	return "", fmt.Errorf("module directive not found in %s", path)
+}
+
+func testcaseAttrs(attrs string) (string, string) {
+	values := map[string]string{}
+	for _, match := range attrPattern.FindAllStringSubmatch(attrs, -1) {
+		if len(match) == 3 {
+			values[match[1]] = match[2]
+		}
+	}
+	testName := strings.Split(values["name"], "/")[0]
+	return values["classname"], testName
+}
+
+func testFileFor(modulePath, className, testName string, cache map[string]string) string {
+	pkgDir := packageDir(modulePath, className)
+	if pkgDir == "" {
+		return ""
+	}
+
+	cacheKey := pkgDir + "\x00" + testName
+	if cached, ok := cache[cacheKey]; ok {
+		return cached
+	}
+
+	file := findTestFile(pkgDir, testName)
+	cache[cacheKey] = file
+	return file
+}
+
+func packageDir(modulePath, className string) string {
+	if className == modulePath {
+		return "."
+	}
+	if !strings.HasPrefix(className, modulePath+"/") {
+		return ""
+	}
+	return filepath.Clean(strings.TrimPrefix(className, modulePath+"/"))
+}
+
+func findTestFile(dir, testName string) string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+
+	var fallback string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		if fallback == "" {
+			fallback = path
+		}
+		data, err := os.ReadFile(path) // #nosec G304 -- path comes from repository test file discovery.
+		if err != nil {
+			continue
+		}
+		for _, match := range funcPattern.FindAllStringSubmatch(string(data), -1) {
+			if len(match) == 2 && match[1] == testName {
+				return filepath.ToSlash(path)
+			}
+		}
+	}
+	return filepath.ToSlash(fallback)
+}
+
+func escapeAttr(value string) string {
+	replacer := strings.NewReplacer(
+		`&`, `&amp;`,
+		`"`, `&quot;`,
+		`<`, `&lt;`,
+		`>`, `&gt;`,
+	)
+	return replacer.Replace(value)
+}


### PR DESCRIPTION
## Summary
- add real read-only TUI copy/export/open-doc actions
- keep agent config mutation disabled
- preserve secret redaction while keeping local paths useful

## What changed
- Added TUI clipboard, fix-plan export, and docs-open commands behind explicit keypresses.
- Exported redacted fix-plan Markdown under `~/.local/state/nightward/exports` with private file permissions.
- Added OS command builders for clipboard/open behavior and tests for redaction, path preservation, and export permissions.
- Updated README, privacy, testing, remediation, and roadmap docs.

## Why
- Completes the TUI action gap from the high-value buildout plan without adding live config mutation or hidden write paths.

## Validation
- `make verify`
- `gitleaks detect --source . --no-git --redact`
- `go list ./cmd/... ./internal/... | xargs go run golang.org/x/vuln/cmd/govulncheck@latest`
- `go run github.com/google/osv-scanner/v2/cmd/osv-scanner@v2.3.5 scan --recursive ./`
- `npx --yes --package renovate renovate-config-validator renovate.json`
- `npm audit --audit-level=moderate`
- `git diff --check`

## Notes
- The Go JUnit report still validates with the existing Trunk warning about missing testcase file paths; Raycast JUnit validates without warnings.
- TUI export is the only new write path and only runs after the explicit `e` keypress.