### PR TITLE
ci(scorecard): scope publish permissions to job

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -11,8 +11,6 @@ on:
 permissions:
   actions: read
   contents: read
-  id-token: write
-  security-events: write
 
 concurrency:
   group: scorecard-${{ github.ref }}
@@ -22,6 +20,13 @@ jobs:
   scorecard:
     name: Scorecard
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      id-token: write
+      pull-requests: read
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/docs/ci-security.md
+++ b/docs/ci-security.md
@@ -17,6 +17,7 @@ Nightward's CI is meant to prove the project is serious about the same safety po
 - Keep the upstream tag in a nearby comment for maintainability.
 - Use least-privilege workflow and job permissions.
 - Prefer read-only `contents: read` unless a job needs SARIF upload or OIDC.
+- Keep OpenSSF Scorecard publish permissions job-scoped; global `id-token: write` fails Scorecard workflow verification.
 - Keep Trunk Flaky Tests uploads gated on `TRUNK_ORG_URL_SLUG` and `TRUNK_API_TOKEN`.
 - Never make flaky-test quarantining a default CI behavior.
 - Use Renovate instead of Dependabot whenever possible.


### PR DESCRIPTION
## Summary
- moves OpenSSF Scorecard publish permissions from workflow-global scope to the Scorecard job
- documents the Scorecard action restriction so future workflow edits do not reintroduce the failure

## What changed
- keeps top-level workflow permissions read-only
- grants `id-token: write` and `security-events: write` only on the `scorecard` job
- adds a CI security note about job-scoped Scorecard publishing permissions

## Why
The post-merge `main` Scorecard run failed because `publish_results: true` rejects global `id-token: write` permissions. Scorecard's current workflow restrictions require publishing permissions to be scoped to the job running the action.

## Validation
- `trunk check --show-existing --fix --all`
- `trunk fmt --all`
- `git diff --check`
