### PR TITLE
fix(ci): close code scanning and verification gaps

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,8 +21,9 @@
 - [ ] `make test-junit`
 - [ ] `make trunk-flaky-validate`
 - [ ] `trunk check --show-existing --all`
-- [ ] `gitleaks detect --source . --no-git --redact`
-- [ ] `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`
+- [ ] `make gitleaks`
+- [ ] `make govulncheck`
+- [ ] `make fuzz-smoke`
 
 ## Notes
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Gosec static analysis
         run: make gosec
 
+      - name: Fuzz smoke
+        run: make fuzz-smoke
+
   trunk:
     name: Trunk Check
     runs-on: ubuntu-latest
@@ -83,11 +86,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Install Trunk
+        run: |
+          set -euo pipefail
+          curl -fsSLo /tmp/trunk https://trunk.io/releases/trunk
+          chmod +x /tmp/trunk
+          sudo mv /tmp/trunk /usr/local/bin/trunk
+
       - name: Run Trunk Check
-        uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4
-        with:
-          check-mode: all
-          arguments: --show-existing --no-fix
+        run: trunk check --show-existing --all --no-fix
 
   raycast:
     name: Raycast extension
@@ -162,10 +169,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make gitleaks
 
   govulncheck:
     name: Go vulnerability scan
@@ -174,21 +185,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Run govulncheck
-        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
-          go-package: ./...
-          repo-checkout: false
+          cache: true
+
+      - name: Run govulncheck
+        run: make govulncheck
 
   osv:
     name: OSV dependency scan
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@c51854704019a247608d928f370c98740469d4b5 # v2.3.5
-    with:
-      scan-args: |-
-        --recursive
-        ./
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run OSV Scanner
+        uses: google/osv-scanner-action/osv-scanner-action@c51854704019a247608d928f370c98740469d4b5 # v2.3.5
+        with:
+          scan-args: |-
+            --recursive
+            ./

--- a/.github/workflows/nightward-policy.yml
+++ b/.github/workflows/nightward-policy.yml
@@ -9,7 +9,6 @@ on:
 permissions:
   actions: read
   contents: read
-  security-events: write
 
 concurrency:
   group: nightward-policy-${{ github.ref }}
@@ -19,6 +18,10 @@ jobs:
   sarif:
     name: Generate Nightward SARIF
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -30,11 +33,10 @@ jobs:
           cache: true
 
       - name: Build policy SARIF
-        env:
-          NIGHTWARD_HOME: ${{ github.workspace }}/testdata/homes/policy
-        run: go run ./cmd/nw policy sarif --output nightward.sarif
+        run: go run ./cmd/nw policy sarif --workspace "${GITHUB_WORKSPACE}" --output nightward.sarif
 
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           sarif_file: nightward.sarif
+          category: nightward-policy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,7 @@ on:
       - "v*.*.*"
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 concurrency:
   group: release-${{ github.ref }}
@@ -17,6 +16,9 @@ jobs:
   release:
     name: GoReleaser
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
 PREFIX ?= $(HOME)/.local
 REPORTS_DIR ?= reports
 GOTESTSUM_VERSION ?= v1.13.0
+GITLEAKS_VERSION ?= v8.30.1
+GOVULNCHECK_VERSION ?= v1.3.0
 GOSEC_VERSION ?= v2.26.1
 STATICCHECK_VERSION ?= v0.7.0
 RAYCAST_DIR ?= integrations/raycast
 GO_PACKAGES ?= $(shell go list ./cmd/... ./internal/... ./tools/...)
 
-.PHONY: test test-race vet staticcheck gosec go-test-junit test-junit trunk-check trunk-fix trunk-flaky-validate raycast-install raycast-test raycast-test-junit raycast-audit raycast-lint raycast-build raycast-verify verify build install-local clean-reports
+.PHONY: test test-race vet staticcheck gosec gitleaks govulncheck fuzz-smoke go-test-junit test-junit trunk-check trunk-fix trunk-flaky-validate raycast-install raycast-test raycast-test-junit raycast-audit raycast-lint raycast-build raycast-verify verify build install-local clean-reports
 
 test:
 	go test $(GO_PACKAGES)
@@ -22,6 +24,15 @@ staticcheck:
 
 gosec:
 	go run github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION) -exclude-generated -exclude-dir=$(RAYCAST_DIR)/node_modules -exclude-dir=$(RAYCAST_DIR)/dist ./...
+
+gitleaks:
+	go run github.com/zricethezav/gitleaks/v8@$(GITLEAKS_VERSION) detect --source . --redact --no-banner
+
+govulncheck:
+	go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...
+
+fuzz-smoke:
+	go test ./internal/inventory -run=^$$ -fuzz=FuzzMCPConfigParsing -fuzztime=10s
 
 go-test-junit:
 	mkdir -p $(REPORTS_DIR)
@@ -60,7 +71,7 @@ raycast-build:
 
 raycast-verify: raycast-install raycast-test raycast-audit raycast-lint raycast-build
 
-verify: test test-race vet staticcheck gosec test-junit trunk-flaky-validate trunk-check raycast-audit raycast-lint raycast-build
+verify: test test-race vet staticcheck gosec gitleaks govulncheck fuzz-smoke test-junit trunk-flaky-validate trunk-check raycast-audit raycast-lint raycast-build
 
 build:
 	go build -o bin/nightward ./cmd/nightward

--- a/README.md
+++ b/README.md
@@ -11,6 +11,32 @@ It scans common Codex, Claude, Cursor, Windsurf, VS Code, Raycast, JetBrains, Ze
 
 Nightward does not mutate agent configs. It only writes explicit report/SARIF files when requested and user-level schedule files through explicit schedule install/remove commands.
 
+> [!IMPORTANT]
+> Nightward is local-first by design: no telemetry, no default network calls, no cloud dashboard, and no live agent-config mutation.
+
+## At A Glance
+
+| Surface | What it does | Default write behavior |
+| --- | --- | --- |
+| TUI | Dashboard, inventory, findings, analysis, fix plan, backup preview | Read-only except explicit redacted export |
+| CLI | Scriptable scan, doctor, policy, SARIF, snapshot, schedule commands | Read-only unless output/schedule flags are explicit |
+| Raycast | macOS read-only companion commands | Clipboard/report-folder actions only |
+| GitHub Action | Workspace policy and SARIF checks | Writes only requested CI outputs |
+| Trunk plugin | Local workspace policy/analyze linters | Emits SARIF to stdout |
+
+```mermaid
+flowchart LR
+  configs["AI agent/devtool config"] --> scan["nw scan"]
+  scan --> classify["classify paths"]
+  scan --> mcp["review MCP trust boundaries"]
+  classify --> tui["TUI"]
+  classify --> json["redacted JSON"]
+  mcp --> findings["findings + analysis signals"]
+  findings --> fix["plan-only fix previews"]
+  findings --> sarif["policy SARIF"]
+  classify --> backup["dry-run backup plan"]
+```
+
 ## Why
 
 AI coding tools scatter useful state across config files, MCP server definitions, skills, rules, commands, extension settings, credentials, caches, and app-owned databases. Blindly syncing all of it is fragile and unsafe.
@@ -44,6 +70,9 @@ Nightward answers the practical questions first:
 - Read-only Raycast extension for Dashboard, Findings, Analysis, Provider Doctor, Explain Finding/Signal, Fix Plan/Analysis export, and report-folder access.
 - User-level nightly scan scheduling for macOS launchd, Linux systemd user timers, and cron text fallback.
 - No telemetry, no cloud dashboard, no network calls from Nightward runtime, and no live config mutation.
+
+> [!TIP]
+> A practical first pass is `nw doctor --json`, then `nw scan --json`, then `nw fix plan --all --json`.
 
 ## Install
 
@@ -167,6 +196,19 @@ Nightward classifies discovered state as:
 
 Backup plans include portable items, mark machine-local/unknown items for review, and exclude secret/auth, runtime-cache, and app-owned state by default.
 
+```mermaid
+flowchart TD
+  found["Discovered path"] --> class{"Classification"}
+  class -->|portable| include["include in private backup plan"]
+  class -->|machine-local or unknown| review["review before syncing"]
+  class -->|secret-auth| excludeSecret["exclude by default"]
+  class -->|runtime-cache| excludeCache["exclude by default"]
+  class -->|app-owned| export["prefer app-supported export"]
+```
+
+> [!WARNING]
+> Do not blindly sync `secret-auth`, `runtime-cache`, or `app-owned` paths. Nightward excludes them by default because those files often contain credentials, generated state, or app-private databases.
+
 ## Fix Plan Model
 
 Nightward does not apply fixes yet. "Autofix" currently means structured, reviewable fix plans:
@@ -189,6 +231,19 @@ Secret values are never emitted in scan JSON, findings output, fix-plan JSON, Ma
 Default analysis is offline and built in. Optional providers such as `gitleaks`, `trufflehog`, `semgrep`, `trivy`, `osv-scanner`, and `socket` are discovered by `providers doctor`; Nightward does not install them or call online services unless a user explicitly selects providers and opts into network-capable behavior.
 
 Policy config can enable analysis and selected provider posture with `include_analysis`, `analysis_threshold`, `analysis_providers`, and `allow_online_providers`.
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Nightward
+  participant LocalTool as Optional local provider
+  User->>Nightward: nw analyze --all
+  Nightward-->>User: offline built-in signals
+  User->>Nightward: nw providers doctor --with socket --online
+  Nightward->>LocalTool: run only after explicit provider + online opt-in
+  LocalTool-->>Nightward: provider signals
+  Nightward-->>User: redacted analysis report
+```
 
 ## TUI
 
@@ -311,8 +366,9 @@ Local security checks used by maintainers:
 
 ```sh
 trunk check --show-existing --all
-gitleaks detect --source . --no-git --redact
-go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+make gitleaks
+make govulncheck
+make fuzz-smoke
 ```
 
 ## Project Docs

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,6 +22,10 @@ Nightward is intentionally staged. The scanner and policy model need to stay tru
 - More MCP config shapes for Codex, Claude Code, and editor integrations.
 - Raycast screenshots, store metadata, and manual development-mode smoke after the first release candidate.
 - Golden SARIF snapshots and broader no-write tests.
+- Bubble Tea/Bubbles TUI upgrade with list, table, viewport, textinput, help, filter modal, command palette, report history, and mouse-wheel support.
+- Optional provider execution for local scanners with timeouts, file-size caps, redaction, and explicit online-provider opt-in.
+- Fuzz coverage for MCP JSON/TOML/YAML parsing, URL/header redaction, symlink traversal, huge files, and malformed configs.
+- Threat model documentation for provider execution, report exports, scheduler behavior, and SARIF uploads.
 - Validate GoReleaser on the first release candidate tag.
 - Screenshot and GIF assets for the README.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,7 @@ Nightward is pre-1.0. Security fixes target `main` until tagged releases exist.
 
 ## Reporting a Vulnerability
 
-Open a private security advisory on GitHub if available. If not, open a public issue with sensitive details removed and say that you need a private disclosure channel.
+Open a private security advisory through [GitHub Security Advisories](https://github.com/JSONbored/nightward/security/advisories/new) if available. If that path is unavailable, open a public issue with sensitive details removed and say that you need a private disclosure channel.
 
 Do not include real tokens, auth files, private MCP configs, or personal paths in reports. Redact values and keep only the minimum config shape needed to reproduce the issue.
 

--- a/docs/ci-security.md
+++ b/docs/ci-security.md
@@ -4,8 +4,8 @@ Nightward's CI is meant to prove the project is serious about the same safety po
 
 ## Workflows
 
-- `ci.yml`: Go tests, race tests, `go vet`, `staticcheck`, `gosec`, JUnit reports, local JUnit shape validation, gated Trunk Flaky Tests uploads, Trunk Check, Raycast extension tests/build/audit, Gitleaks, govulncheck, and OSV dependency scanning.
-- `nightward-policy.yml`: generates Nightward SARIF from a fixture home and uploads it to GitHub code scanning.
+- `ci.yml`: Go tests, race tests, `go vet`, `staticcheck`, `gosec`, fuzz smoke tests, JUnit reports, local JUnit shape validation, gated Trunk Flaky Tests uploads, explicit Trunk Check CLI execution, Raycast extension tests/build/audit, Gitleaks, govulncheck, and OSV dependency scanning.
+- `nightward-policy.yml`: generates workspace Nightward SARIF and uploads it to GitHub code scanning without scanning synthetic risky fixture homes.
 - `plugin.yaml`: defines Trunk Check linters for workspace policy and analysis SARIF once release tags are available.
 - `scorecard.yml`: runs OpenSSF Scorecard and uploads SARIF.
 - `release.yml`: publishes signed GoReleaser artifacts from strict `vX.Y.Z` tags.
@@ -18,10 +18,12 @@ Nightward's CI is meant to prove the project is serious about the same safety po
 - Use least-privilege workflow and job permissions.
 - Prefer read-only `contents: read` unless a job needs SARIF upload or OIDC.
 - Keep OpenSSF Scorecard publish permissions job-scoped; global `id-token: write` fails Scorecard workflow verification.
+- Keep release publish permissions job-scoped; top-level workflow permissions should stay read-only unless every job truly needs write access.
 - Keep Trunk Flaky Tests uploads gated on `TRUNK_ORG_URL_SLUG` and `TRUNK_API_TOKEN`.
 - Never make flaky-test quarantining a default CI behavior.
 - Use Renovate instead of Dependabot whenever possible.
 - Keep dependency PRs reviewed; do not enable broad automerge by default.
+- Use repo-controlled `make gitleaks` and `make govulncheck` targets in CI so local and remote behavior match.
 
 ## Trunk Plugin Notes
 

--- a/docs/dependency-maintenance.md
+++ b/docs/dependency-maintenance.md
@@ -7,7 +7,7 @@ Nightward uses Renovate instead of Dependabot.
 - Go modules in `go.mod` and `go.sum`.
 - Raycast extension packages in `integrations/raycast/package.json` and `package-lock.json`.
 - GitHub Actions versions and pinned action digests.
-- `gotestsum` in `Makefile`.
+- `gotestsum`, `gitleaks`, and `govulncheck` pins in `Makefile`.
 - GoReleaser binary version in `.github/workflows/release.yml`.
 - Trunk plugin registry pin in `.trunk/trunk.yaml`.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,6 +10,9 @@ make test-race
 make vet
 make staticcheck
 make gosec
+make gitleaks
+make govulncheck
+make fuzz-smoke
 make test-junit
 make trunk-flaky-validate
 make trunk-check
@@ -33,8 +36,9 @@ make verify
 - MCP fixture tests should cover command servers, URL-shaped servers, sensitive headers, local endpoints, and unsupported shapes.
 - Scheduler tests verify generated launchd, systemd user timer, and cron text without installing schedules.
 - TUI action tests cover clipboard/open command construction and private redacted fix-plan exports.
+- TUI model tests cover tab switching, search, filters, help, cursor clamping, wide detail panes, compact terminal rendering, and redaction.
 - Raycast extension tests cover pure redaction/formatting helpers and safe command execution wrappers.
-- `go vet`, `staticcheck`, and `gosec` are part of the local verification bar. `#nosec` comments must include a narrow reason tied to an intentional local CLI behavior.
+- `go vet`, `staticcheck`, `gosec`, `gitleaks`, `govulncheck`, and fuzz smoke tests are part of the local verification bar. `#nosec` comments must include a narrow reason tied to an intentional local CLI behavior.
 - Raycast dependency audits run with `npm audit --audit-level=moderate`.
 
 ## Trunk Flaky Tests

--- a/integrations/raycast/src/format.ts
+++ b/integrations/raycast/src/format.ts
@@ -108,7 +108,7 @@ export function findingMarkdown(finding: Finding): string {
     "",
     "## Evidence",
     finding.evidence
-      ? `\`${escapeCode(redactText(finding.evidence))}\``
+      ? markdownCode(redactText(finding.evidence))
       : "No redacted evidence was emitted for this finding.",
     "",
     "## Impact",
@@ -159,7 +159,7 @@ export function signalMarkdown(signal: AnalysisSignal): string {
     "",
     "## Evidence",
     signal.evidence
-      ? `\`${escapeCode(redactText(signal.evidence))}\``
+      ? markdownCode(redactText(signal.evidence))
       : "No redacted evidence was emitted for this signal.",
     "",
     "## Recommended Action",
@@ -170,7 +170,7 @@ export function signalMarkdown(signal: AnalysisSignal): string {
     `Category: \`${signal.category}\``,
     `Severity: \`${signal.severity}\``,
     `Confidence: \`${signal.confidence}\``,
-    signal.path ? `Path: \`${escapeCode(signal.path)}\`` : "",
+    signal.path ? `Path: ${markdownCode(signal.path)}` : "",
     signal.why_this_matters ? "" : "",
     signal.why_this_matters ? "## Why This Matters" : "",
     signal.why_this_matters ? redactText(signal.why_this_matters) : "",
@@ -263,10 +263,56 @@ export function truncate(value: string, maxLength: number): string {
   return `${value.slice(0, maxLength - 3)}...`;
 }
 
-function escapeCode(value: string): string {
-  return value.replace(/`/g, "\\`");
+function markdownCode(value: string): string {
+  const longestRun = maxBacktickRun(value);
+  const delimiter = "`".repeat(longestRun + 1);
+  const padded =
+    value.startsWith("`") || value.endsWith("`") ? ` ${value} ` : value;
+  return `${delimiter}${padded}${delimiter}`;
 }
 
 function escapeMarkdown(value: string): string {
-  return value.replace(/([*_#[\]])/g, "\\$1");
+  const escaped: string[] = [];
+  for (const char of value) {
+    if (markdownSpecialChars.has(char)) {
+      escaped.push("\\");
+    }
+    escaped.push(char);
+  }
+  return escaped.join("");
 }
+
+function maxBacktickRun(value: string): number {
+  let max = 0;
+  let current = 0;
+  for (const char of value) {
+    if (char === "`") {
+      current += 1;
+      if (current > max) max = current;
+    } else {
+      current = 0;
+    }
+  }
+  return max;
+}
+
+const markdownSpecialChars = new Set([
+  "\\",
+  "`",
+  "*",
+  "_",
+  "{",
+  "}",
+  "[",
+  "]",
+  "(",
+  ")",
+  "#",
+  "+",
+  "-",
+  ".",
+  "!",
+  "|",
+  ">",
+  "~",
+]);

--- a/integrations/raycast/test/format.test.ts
+++ b/integrations/raycast/test/format.test.ts
@@ -59,6 +59,25 @@ test("finding markdown keeps guidance while avoiding secret values", () => {
   assert.doesNotMatch(markdown, /1234567890abcdef/);
 });
 
+test("markdown helpers preserve escaped evidence without leaking formatting", () => {
+  const finding: Finding = {
+    id: "mcp_review-escaping",
+    tool: "Codex",
+    path: "/tmp/config.toml",
+    severity: "medium",
+    rule: "mcp_[review]\\path",
+    message: "Review `server` path.",
+    evidence: "command=`node` path=C:\\Users\\example",
+    recommended_action: "Review manually.",
+    fix_available: false,
+    requires_review: true,
+  };
+
+  const markdown = findingMarkdown(finding);
+  assert.match(markdown, /^# mcp\\_\\\[review\\\]\\\\path/m);
+  assert.match(markdown, /``command=`node` path=C:\\Users\\example``/);
+});
+
 test("findings sort by severity then stable identity", () => {
   const findings: Finding[] = [
     baseFinding("b", "low", "Cursor"),

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -36,6 +36,9 @@ func TestReadOnlyCommandsDoNotMutateHome(t *testing.T) {
 		{"snapshot", "plan", "--target", filepath.Join(home, "snapshot"), "--json"},
 		{"policy", "sarif", "--output", filepath.Join(outputDir, "nightward.sarif")},
 		{"policy", "sarif", "--include-analysis", "--output", "-"},
+		{"schedule", "plan", "--preset", "nightly", "--json"},
+		{"schedule", "install", "--preset", "nightly", "--dry-run", "--json"},
+		{"schedule", "remove", "--dry-run", "--json"},
 	}
 	for _, args := range commands {
 		var stdout, stderr bytes.Buffer
@@ -54,6 +57,146 @@ func TestReadOnlyCommandsDoNotMutateHome(t *testing.T) {
 	targetAfter := listOptionalTestFiles(t, targetDir)
 	if strings.Join(targetBefore, "\n") != strings.Join(targetAfter, "\n") {
 		t.Fatalf("read-only backup plan mutated target\nbefore=%v\nafter=%v", targetBefore, targetAfter)
+	}
+}
+
+func TestPublicCommandMatrixAndRedaction(t *testing.T) {
+	home := t.TempDir()
+	secretValue := "super-" + "secret-value"
+	writeTestFile(t, filepath.Join(home, ".codex", "config.toml"), `[mcp_servers.demo]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "/"]
+
+[mcp_servers.demo.env]
+API_TOKEN = "`+secretValue+`"
+`)
+	t.Setenv("NIGHTWARD_HOME", home)
+
+	findingID := firstFindingID(t, []string{"findings", "list", "--json"})
+	jsonCommands := [][]string{
+		{"scan", "--json"},
+		{"doctor", "--json"},
+		{"adapters", "list", "--json"},
+		{"findings", "list", "--json"},
+		{"findings", "explain", "--json", findingID},
+		{"fix", "plan", "--all", "--json"},
+		{"fix", "preview", "--all", "--format", "json"},
+		{"analyze", "--all", "--json"},
+		{"analyze", "finding", "--json", findingID},
+		{"trust", "explain", "--json", findingID},
+		{"providers", "list", "--json"},
+		{"providers", "doctor", "--json"},
+		{"policy", "check", "--json"},
+		{"policy", "sarif", "--output", "-"},
+		{"snapshot", "plan", "--target", filepath.Join(home, "snapshots"), "--json"},
+		{"schedule", "plan", "--json"},
+		{"schedule", "install", "--dry-run", "--json"},
+		{"schedule", "remove", "--dry-run", "--json"},
+	}
+	for _, args := range jsonCommands {
+		stdout, stderr, code := runCLI(args)
+		if args[0] == "policy" && args[1] == "check" {
+			if code != 1 {
+				t.Fatalf("%s expected policy violation exit 1, got %d stderr=%s", strings.Join(args, " "), code, stderr)
+			}
+		} else if code != 0 {
+			t.Fatalf("%s failed with %d: %s", strings.Join(args, " "), code, stderr)
+		}
+		if !json.Valid([]byte(stdout)) {
+			t.Fatalf("%s did not emit valid JSON:\n%s\nstderr=%s", strings.Join(args, " "), stdout, stderr)
+		}
+		assertNoSecret(t, stdout, secretValue)
+	}
+
+	textCommands := [][]string{
+		{"scan"},
+		{"doctor"},
+		{"plan", "backup", "--target", filepath.Join(home, "backup")},
+		{"findings", "list"},
+		{"findings", "explain", findingID},
+		{"fix", "plan", "--all"},
+		{"fix", "preview", "--all", "--format", "markdown"},
+		{"fix", "export", "--all", "--format", "markdown"},
+		{"analyze", "--all"},
+		{"trust", "explain", findingID},
+		{"policy", "init", "--dry-run"},
+		{"policy", "explain"},
+		{"schedule", "install", "--dry-run"},
+	}
+	for _, args := range textCommands {
+		stdout, stderr, code := runCLI(args)
+		if code != 0 {
+			t.Fatalf("%s failed with %d: %s", strings.Join(args, " "), code, stderr)
+		}
+		if stdout == "" {
+			t.Fatalf("%s produced no stdout", strings.Join(args, " "))
+		}
+		assertNoSecret(t, stdout, secretValue)
+	}
+
+	failures := [][]string{
+		{"plan", "backup", "--json"},
+		{"fix", "preview", "--all", "--format", "xml"},
+		{"policy", "init"},
+		{"snapshot", "diff", "--from", "missing.json"},
+		{"schedule", "install", "--preset", "bogus", "--dry-run"},
+	}
+	for _, args := range failures {
+		_, _, code := runCLI(args)
+		if code == 0 {
+			t.Fatalf("%s unexpectedly succeeded", strings.Join(args, " "))
+		}
+	}
+}
+
+func TestScanOutputModesHaveEquivalentSummaries(t *testing.T) {
+	home := t.TempDir()
+	writeTestFile(t, filepath.Join(home, ".mcp.json"), `{"mcpServers":{"demo":{"command":"node","args":["server.js"]}}}`)
+	t.Setenv("NIGHTWARD_HOME", home)
+	outputFile := filepath.Join(t.TempDir(), "scan.json")
+	outputDir := t.TempDir()
+
+	stdoutJSON, stderr, code := runCLI([]string{"scan", "--json"})
+	if code != 0 {
+		t.Fatalf("scan --json failed: %s", stderr)
+	}
+	stdoutDash, stderr, code := runCLI([]string{"scan", "--output", "-"})
+	if code != 0 {
+		t.Fatalf("scan --output - failed: %s", stderr)
+	}
+	_, stderr, code = runCLI([]string{"scan", "--output", outputFile})
+	if code != 0 {
+		t.Fatalf("scan --output file failed: %s", stderr)
+	}
+	_, stderr, code = runCLI([]string{"scan", "--output-dir", outputDir})
+	if code != 0 {
+		t.Fatalf("scan --output-dir failed: %s", stderr)
+	}
+
+	want := scanSummary(t, stdoutJSON)
+	if got := scanSummary(t, stdoutDash); got != want {
+		t.Fatalf("stdout summary mismatch: got=%s want=%s", got, want)
+	}
+	fileData, err := os.ReadFile(outputFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := scanSummary(t, string(fileData)); got != want {
+		t.Fatalf("file summary mismatch: got=%s want=%s", got, want)
+	}
+	matches, err := filepath.Glob(filepath.Join(outputDir, "nightward-scan-*.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected one output-dir report, got %v", matches)
+	}
+	dirData, err := os.ReadFile(matches[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := scanSummary(t, string(dirData)); got != want {
+		t.Fatalf("output-dir summary mismatch: got=%s want=%s", got, want)
 	}
 }
 
@@ -86,6 +229,28 @@ func TestWorkspaceCommandsAreReadOnlyAndSupportStdoutSARIF(t *testing.T) {
 	after := listTestFiles(t, workspace)
 	if strings.Join(before, "\n") != strings.Join(after, "\n") {
 		t.Fatalf("workspace commands mutated files\nbefore=%v\nafter=%v", before, after)
+	}
+}
+
+func TestWorkspaceScanDoesNotReadHomeFixtures(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	writeTestFile(t, filepath.Join(home, ".codex", "config.toml"), `[mcp_servers.home_only]
+command = "npx"
+args = ["-y", "@example/home-only"]
+`)
+	writeTestFile(t, filepath.Join(workspace, ".cursor", "mcp.json"), `{"mcpServers":{"workspaceOnly":{"url":"https://mcp.example.test/server"}}}`)
+	t.Setenv("NIGHTWARD_HOME", home)
+
+	stdout, stderr, code := runCLI([]string{"scan", "--workspace", workspace, "--json"})
+	if code != 0 {
+		t.Fatalf("workspace scan failed: %s", stderr)
+	}
+	if strings.Contains(stdout, "home_only") || strings.Contains(stdout, filepath.Join(home, ".codex")) {
+		t.Fatalf("workspace scan included HOME-only config:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "workspaceOnly") {
+		t.Fatalf("workspace scan missed workspace config:\n%s", stdout)
 	}
 }
 
@@ -180,4 +345,49 @@ func listOptionalTestFiles(t *testing.T, root string) []string {
 		return nil
 	}
 	return listTestFiles(t, root)
+}
+
+func runCLI(args []string) (string, string, int) {
+	var stdout, stderr bytes.Buffer
+	code := RunWithName("nw", args, &stdout, &stderr)
+	return stdout.String(), stderr.String(), code
+}
+
+func firstFindingID(t *testing.T, args []string) string {
+	t.Helper()
+	stdout, stderr, code := runCLI(args)
+	if code != 0 {
+		t.Fatalf("%s failed: %s", strings.Join(args, " "), stderr)
+	}
+	var findings []struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &findings); err != nil {
+		t.Fatal(err)
+	}
+	if len(findings) == 0 {
+		t.Fatal("expected at least one finding")
+	}
+	return findings[0].ID
+}
+
+func assertNoSecret(t *testing.T, output, secret string) {
+	t.Helper()
+	if strings.Contains(output, secret) {
+		t.Fatalf("output leaked secret %q:\n%s", secret, output)
+	}
+}
+
+func scanSummary(t *testing.T, data string) string {
+	t.Helper()
+	var decoded struct {
+		Summary json.RawMessage `json:"summary"`
+	}
+	if err := json.Unmarshal([]byte(data), &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded.Summary) == 0 {
+		t.Fatalf("missing summary in %s", data)
+	}
+	return string(decoded.Summary)
 }

--- a/internal/inventory/mcp_fuzz_test.go
+++ b/internal/inventory/mcp_fuzz_test.go
@@ -1,0 +1,22 @@
+package inventory
+
+import "testing"
+
+func FuzzMCPConfigParsing(f *testing.F) {
+	f.Add(`{"mcpServers":{"demo":{"command":"npx","args":["@example/server"],"env":{"API_TOKEN":"${API_TOKEN}"}}}}`)
+	f.Add(`[mcp_servers.demo]
+url = "http://127.0.0.1:8787/mcp"
+
+[mcp_servers.demo.headers]
+Authorization = "Bearer secret"
+`)
+	f.Add(`{"servers":{"broken":{"headers":{"X-API-Key":"inline-secret"},"args":[1,true,null]}}}`)
+
+	f.Fuzz(func(t *testing.T, data string) {
+		if len(data) > 4096 {
+			t.Skip("cap fuzz input size for parser smoke coverage")
+		}
+		_, _ = readJSONServers([]byte(data))
+		_, _ = readTOMLServers([]byte(data))
+	})
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -75,6 +75,8 @@ var (
 )
 
 var tabs = []string{"Dashboard", "Inventory", "Findings", "Analysis", "Fix Plan", "Backup Plan"}
+var compactTabs = []string{"Dash", "Inv", "Find", "Analysis", "Fix", "Backup"}
+var tinyTabs = []string{"D", "I", "F", "A", "X", "B"}
 
 const remediationDocsURL = "https://github.com/JSONbored/nightward/blob/main/docs/remediation.md"
 const analysisDocsURL = "https://github.com/JSONbored/nightward/blob/main/docs/analysis.md"
@@ -215,7 +217,8 @@ func (m model) View() string {
 	bodyWidth := max(40, width-4)
 	bodyHeight := max(12, m.height-7)
 
-	tabLine := lipgloss.JoinHorizontal(lipgloss.Top, titleStyle.Render("nightward"), m.renderTabs())
+	tabLine := lipgloss.JoinHorizontal(lipgloss.Top, titleStyle.Render("nightward"), m.renderTabs(max(16, bodyWidth-12)))
+	tabLine = lipgloss.NewStyle().Width(bodyWidth).MaxWidth(bodyWidth).Render(tabLine)
 	bodyText := m.renderBody(bodyWidth-6, bodyHeight-2)
 	if m.showHelp {
 		bodyText = m.help(bodyWidth - 6)
@@ -228,13 +231,19 @@ func (m model) View() string {
 	if m.status != "" {
 		footerText += "  " + m.status
 	}
-	footer := footerStyle.Render(footerText)
+	footer := footerStyle.Width(bodyWidth).Render(truncate(footerText, bodyWidth-2))
 	return baseStyle.Render(lipgloss.JoinVertical(lipgloss.Left, tabLine, body, footer))
 }
 
-func (m model) renderTabs() string {
+func (m model) renderTabs(width int) string {
+	labels := tabs
+	if width < 44 {
+		labels = tinyTabs
+	} else if width < 84 {
+		labels = compactTabs
+	}
 	rendered := make([]string, 0, len(tabs))
-	for i, tab := range tabs {
+	for i, tab := range labels {
 		label := fmt.Sprintf("%d %s", i+1, tab)
 		if i == m.tab {
 			rendered = append(rendered, activeTabStyle.Render(label))
@@ -358,6 +367,12 @@ func (m model) findings(width, height int) string {
 
 func (m model) fixPlan(width, height int) string {
 	plan := fixplan.Build(m.report, fixplan.Selector{All: true})
+	listWidth := width
+	detailWidth := 0
+	if width >= 94 {
+		listWidth = width/2 - 1
+		detailWidth = width - listWidth - 3
+	}
 	lines := []string{
 		section("Fix Plan"),
 		fmt.Sprintf("Safe: %d  Review: %d  Blocked: %d", plan.Summary.Safe, plan.Summary.Review, plan.Summary.Blocked),
@@ -380,11 +395,22 @@ func (m model) fixPlan(width, height int) string {
 		lines = append(lines, fmt.Sprintf("%s%-7s %-20s %-22s %s", prefix, fix.Status, fix.FixKind, fix.Rule, fix.Summary))
 	}
 	lines = append(lines, "", "Use `nw fix plan --all --json` or `nw fix export --format markdown` for full steps.")
-	return fitLines(lines, width)
+	left := fitLines(lines, listWidth)
+	if detailWidth <= 0 {
+		return left
+	}
+	detail := fixDetail(plan.Fixes[m.cursor], detailWidth, height)
+	return lipgloss.JoinHorizontal(lipgloss.Top, left, "  ", detail)
 }
 
 func (m model) analysis(width, height int) string {
 	report := analysis.Run(m.report, analysis.Options{Mode: m.report.ScanMode, Workspace: m.report.Workspace})
+	listWidth := width
+	detailWidth := 0
+	if width >= 94 {
+		listWidth = width/2 - 1
+		detailWidth = width - listWidth - 3
+	}
 	lines := []string{
 		section("Analysis"),
 		fmt.Sprintf("Signals: %d  Subjects: %d  Highest: %s  Provider warnings: %d", report.Summary.TotalSignals, report.Summary.TotalSubjects, report.Summary.HighestSeverity, report.Summary.ProviderWarnings),
@@ -408,7 +434,12 @@ func (m model) analysis(width, height int) string {
 		lines = append(lines, fmt.Sprintf("%s%-8s %-30s %s", prefix, signal.Severity, signal.Rule, signal.Message))
 	}
 	lines = append(lines, "", "Use `nw analyze --all --json` or `nw providers doctor --json` for full details.")
-	return fitLines(lines, width)
+	left := fitLines(lines, listWidth)
+	if detailWidth <= 0 {
+		return left
+	}
+	detail := signalDetail(report.Signals[m.cursor], detailWidth, height)
+	return lipgloss.JoinHorizontal(lipgloss.Top, left, "  ", detail)
 }
 
 func (m model) backupPlan(width, height int) string {
@@ -633,22 +664,74 @@ func findingDetail(finding inventory.Finding, width, height int) string {
 		finding.ID,
 		fmt.Sprintf("%s / %s / %s", finding.Tool, finding.Severity, finding.Rule),
 		"",
-		finding.Message,
+		redactTUIText(finding.Message),
 	}
 	if finding.Evidence != "" {
-		lines = append(lines, "", section("Evidence"), finding.Evidence)
+		lines = append(lines, "", section("Evidence"), redactTUIText(finding.Evidence))
 	}
 	if finding.Impact != "" {
-		lines = append(lines, "", section("Impact"), finding.Impact)
+		lines = append(lines, "", section("Impact"), redactTUIText(finding.Impact))
 	}
 	if finding.FixAvailable {
-		lines = append(lines, "", section("Suggested Fix"), fmt.Sprintf("%s  confidence=%s  risk=%s", finding.FixKind, finding.Confidence, finding.Risk), finding.FixSummary)
+		lines = append(lines, "", section("Suggested Fix"), fmt.Sprintf("%s  confidence=%s  risk=%s", finding.FixKind, finding.Confidence, finding.Risk), redactTUIText(finding.FixSummary))
 		for i, step := range finding.FixSteps {
-			lines = append(lines, fmt.Sprintf("%d. %s", i+1, step))
+			lines = append(lines, fmt.Sprintf("%d. %s", i+1, redactTUIText(step)))
 		}
 	}
 	if finding.Why != "" {
-		lines = append(lines, "", section("Why"), finding.Why)
+		lines = append(lines, "", section("Why"), redactTUIText(finding.Why))
+	}
+	if len(lines) > height {
+		lines = lines[:height]
+	}
+	return fitLines(lines, width)
+}
+
+func signalDetail(signal analysis.Signal, width, height int) string {
+	lines := []string{
+		section("Signal Detail"),
+		signal.ID,
+		fmt.Sprintf("%s / %s / %s", signal.Provider, signal.Severity, signal.Rule),
+		"",
+		redactTUIText(signal.Message),
+	}
+	if signal.Evidence != "" {
+		lines = append(lines, "", section("Evidence"), redactTUIText(signal.Evidence))
+	}
+	lines = append(lines, "", section("Recommendation"), redactTUIText(signal.Recommendation))
+	lines = append(lines, "", section("Review"), fmt.Sprintf("confidence=%s  category=%s", signal.Confidence, signal.Category))
+	if signal.Why != "" {
+		lines = append(lines, "", section("Why"), redactTUIText(signal.Why))
+	}
+	if len(lines) > height {
+		lines = lines[:height]
+	}
+	return fitLines(lines, width)
+}
+
+func fixDetail(fix fixplan.Fix, width, height int) string {
+	lines := []string{
+		section("Fix Detail"),
+		fix.FindingID,
+		fmt.Sprintf("%s / %s / %s", fix.Tool, fix.Status, fix.Rule),
+		"",
+		redactTUIText(fix.Summary),
+	}
+	if fix.Evidence != "" {
+		lines = append(lines, "", section("Evidence"), redactTUIText(fix.Evidence))
+	}
+	if fix.Impact != "" {
+		lines = append(lines, "", section("Impact"), redactTUIText(fix.Impact))
+	}
+	lines = append(lines, "", section("Review"), fmt.Sprintf("kind=%s  confidence=%s  risk=%s  requires_review=%t", fix.FixKind, fix.Confidence, fix.Risk, fix.RequiresReview))
+	if len(fix.Steps) > 0 {
+		lines = append(lines, "", section("Steps"))
+		for i, step := range fix.Steps {
+			lines = append(lines, fmt.Sprintf("%d. %s", i+1, redactTUIText(step)))
+		}
+	}
+	if fix.Why != "" {
+		lines = append(lines, "", section("Why"), redactTUIText(fix.Why))
 	}
 	if len(lines) > height {
 		lines = lines[:height]
@@ -890,14 +973,25 @@ func fitLines(lines []string, width int) string {
 }
 
 func truncate(line string, width int) string {
-	if width <= 4 || lipgloss.Width(line) <= width {
+	if width <= 0 {
+		return ""
+	}
+	if lipgloss.Width(line) <= width {
 		return line
 	}
-	runes := []rune(line)
-	if len(runes) <= width-1 {
-		return line
+	suffix := "..."
+	if width <= len(suffix) {
+		suffix = ""
 	}
-	return string(runes[:width-1]) + "..."
+	var b strings.Builder
+	for _, r := range line {
+		next := b.String() + string(r)
+		if lipgloss.Width(next+suffix) > width {
+			break
+		}
+		b.WriteRune(r)
+	}
+	return b.String() + suffix
 }
 
 func clampCursor(cursor, total, visible int) int {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -4,10 +4,13 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/jsonbored/nightward/internal/inventory"
 )
 
@@ -46,8 +49,13 @@ func TestFindingsAndFixPlanViewsRenderRedactedDetails(t *testing.T) {
 	}
 
 	fixes := m.fixPlan(116, 32)
-	if !strings.Contains(fixes, "Fix Plan") || !strings.Contains(fixes, "externalize-secret") {
+	if !strings.Contains(fixes, "Fix Plan") || !strings.Contains(fixes, "Fix Detail") || !strings.Contains(fixes, "externalize-secret") {
 		t.Fatalf("fix plan view missing detail:\n%s", fixes)
+	}
+
+	analysis := m.analysis(116, 32)
+	if !strings.Contains(analysis, "Analysis") || !strings.Contains(analysis, "Signal Detail") || !strings.Contains(analysis, "secrets-exposure") {
+		t.Fatalf("analysis view missing detail:\n%s", analysis)
 	}
 }
 
@@ -107,6 +115,100 @@ func TestTUIActionSelectionAndDocsURL(t *testing.T) {
 	}
 }
 
+func TestTUIUpdateFiltersSearchAndHelp(t *testing.T) {
+	report := inventory.Report{Findings: []inventory.Finding{
+		{ID: "one", Tool: "Codex", Rule: "mcp_secret_env", Severity: inventory.RiskCritical, Message: "Sensitive key", Evidence: "env_key=API_TOKEN"},
+		{ID: "two", Tool: "Cursor", Rule: "mcp_server_review", Severity: inventory.RiskInfo, Message: "Review server"},
+	}}
+	m := model{report: report, width: 100, height: 30}
+
+	updated, _ := m.Update(key("3"))
+	m = updated.(model)
+	if m.tab != 2 {
+		t.Fatalf("expected findings tab, got %d", m.tab)
+	}
+	updated, _ = m.Update(key("s"))
+	m = updated.(model)
+	if m.severity != string(inventory.RiskCritical) {
+		t.Fatalf("expected severity filter, got %q", m.severity)
+	}
+	updated, _ = m.Update(key("/"))
+	m = updated.(model)
+	if !m.searching {
+		t.Fatal("expected search mode")
+	}
+	for _, r := range "api_token" {
+		updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = updated.(model)
+	}
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if m.searching || m.search != "api_token" || len(m.filteredFindings()) != 1 {
+		t.Fatalf("unexpected search state: searching=%t search=%q filtered=%d", m.searching, m.search, len(m.filteredFindings()))
+	}
+	updated, _ = m.Update(key("?"))
+	m = updated.(model)
+	if !m.showHelp || !strings.Contains(m.View(), "Help") {
+		t.Fatal("expected help view")
+	}
+	updated, _ = m.Update(key("x"))
+	m = updated.(model)
+	if m.severity != "" || m.search != "" {
+		t.Fatalf("expected filters cleared, severity=%q search=%q", m.severity, m.search)
+	}
+}
+
+func TestTUIViewResponsiveWidths(t *testing.T) {
+	report := inventory.Report{
+		GeneratedAt: time.Date(2026, 4, 30, 7, 0, 0, 0, time.UTC),
+		Home:        "/tmp/nightward-home-with-a-long-path",
+		Hostname:    "host.example",
+		Items: []inventory.Item{
+			{Tool: "Codex", Classification: inventory.Portable, Risk: inventory.RiskLow, Path: "/tmp/nightward-home-with-a-long-path/.codex/config.toml"},
+		},
+		Findings: []inventory.Finding{
+			{
+				ID:             "mcp_secret_env-111111111111",
+				Tool:           "Codex",
+				Path:           "/tmp/nightward-home-with-a-long-path/.codex/config.toml",
+				Severity:       inventory.RiskCritical,
+				Rule:           "mcp_secret_env",
+				Message:        "MCP server stores a sensitive environment key with a long explanatory message.",
+				Evidence:       "env_key=API_TOKEN",
+				FixAvailable:   true,
+				FixKind:        inventory.FixExternalizeSecret,
+				Confidence:     "high",
+				Risk:           inventory.RiskHigh,
+				RequiresReview: true,
+				FixSummary:     "Move API_TOKEN out of this config.",
+				FixSteps:       []string{"Remove API_TOKEN=super-" + "secret-value from the MCP config."},
+			},
+		},
+	}
+	for _, size := range []struct {
+		width  int
+		height int
+	}{
+		{80, 24},
+		{120, 40},
+		{160, 50},
+	} {
+		m := model{report: report, width: size.width, height: size.height}
+		for tab := range tabs {
+			m.tab = tab
+			rendered := stripANSI(m.View())
+			if strings.Contains(rendered, "super-secret-value") {
+				t.Fatalf("view leaked secret at width %d tab %d:\n%s", size.width, tab, rendered)
+			}
+			for _, line := range strings.Split(rendered, "\n") {
+				if got := lipgloss.Width(line); got > size.width {
+					t.Fatalf("line width %d exceeds terminal width %d on tab %d:\n%s", got, size.width, tab, line)
+				}
+			}
+		}
+	}
+}
+
 func TestExportFixPlanWritesRedactedMarkdown(t *testing.T) {
 	home := t.TempDir()
 	secretValue := "super-" + "secret-value"
@@ -161,6 +263,16 @@ func TestExportFixPlanWritesRedactedMarkdown(t *testing.T) {
 		t.Fatalf("expected private export mode 0600, got %s", got)
 	}
 }
+
+func key(value string) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(value)}
+}
+
+func stripANSI(value string) string {
+	return ansiPattern.ReplaceAllString(value, "")
+}
+
+var ansiPattern = regexp.MustCompile(`\x1b\[[0-9;?]*[A-Za-z]`)
 
 func TestClipboardAndOpenCommandBuilders(t *testing.T) {
 	lookup := func(name string) (string, error) {

--- a/renovate.json
+++ b/renovate.json
@@ -44,6 +44,14 @@
       "labels": ["dependencies", "go", "test"]
     },
     {
+      "matchPackageNames": [
+        "github.com/zricethezav/gitleaks/v8",
+        "golang.org/x/vuln"
+      ],
+      "groupName": "security scan tooling",
+      "labels": ["dependencies", "go", "security"]
+    },
+    {
       "matchPackageNames": ["goreleaser/goreleaser"],
       "groupName": "release tooling",
       "labels": ["dependencies", "release"]
@@ -63,6 +71,26 @@
         "GOTESTSUM_VERSION\\s*\\?=\\s*(?<currentValue>v?\\d+\\.\\d+\\.\\d+)"
       ],
       "depNameTemplate": "gotest.tools/gotestsum",
+      "datasourceTemplate": "go"
+    },
+    {
+      "customType": "regex",
+      "description": "Update Gitleaks used by Makefile secret scanning.",
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": [
+        "GITLEAKS_VERSION\\s*\\?=\\s*(?<currentValue>v?\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "github.com/zricethezav/gitleaks/v8",
+      "datasourceTemplate": "go"
+    },
+    {
+      "customType": "regex",
+      "description": "Update govulncheck used by Makefile vulnerability scanning.",
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": [
+        "GOVULNCHECK_VERSION\\s*\\?=\\s*(?<currentValue>v?\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "golang.org/x/vuln",
       "datasourceTemplate": "go"
     },
     {


### PR DESCRIPTION
## Summary
- fixes the current CI/code-scanning warning surface without changing Nightward's local-first trust boundary
- expands TUI and CLI regression coverage around redaction, width safety, command behavior, no-write behavior, and workspace isolation
- improves README structure with diagrams, callouts, and clearer command guidance

## What changed
- replaced Gitleaks and govulncheck wrapper actions with pinned Make targets managed by Renovate
- switched Trunk Check CI to explicit CLI execution and added a fuzz smoke gate
- tightened workflow permissions for SARIF and release jobs
- changed Nightward policy SARIF CI to scan the workspace instead of the synthetic policy fixture home
- fixed Raycast Markdown/code escaping to address CodeQL incomplete sanitization alerts
- added deterministic TUI model/view tests for filters, search, help, responsive widths, details, and redaction
- added CLI matrix tests for public command paths, parseability, expected failures, no-write behavior, and output parity
- added MCP parser fuzz smoke coverage
- updated SECURITY, testing, CI/security, Renovate, PR checklist, roadmap, and README docs

## Why
The merged baseline was functional, but GitHub code scanning was reporting avoidable CI/tooling issues, fixture SARIF alerts, and Raycast escaping findings. This keeps the project credible before broader adoption and gives future TUI/provider work a stronger test bed.

## Validation
- `make verify`
- `renovate-config-validator renovate.json`
- `actionlint -shellcheck= .github/workflows/*.yml`
- `go run ./cmd/nw --help`
- `go run ./cmd/nw policy sarif --workspace . --output - | jq '[.runs[].results[]?] | length'`
- manual TUI launch/quit smoke with a temp HOME
- `git diff --check`

## Notes
- Scorecard `Maintained` is repository-age/activity based and cannot be fully closed by code in this PR.
- Scorecard `Code-Review` depends on reviewed PR history and branch/ruleset behavior; this PR should be reviewed rather than force-merged if we want to improve that signal.
- Scorecard `CII-Best-Practices` still requires a real OpenSSF Best Practices project/badge setup outside the repo.
- Existing Nightward SARIF alerts on `main` should clear after this workflow runs on `main`, because policy SARIF now scans the workspace instead of `testdata/homes/policy`.
