### PR TITLE
docs(security): add openssf badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/JSONbored/nightward/actions/workflows/ci.yml/badge.svg)](https://github.com/JSONbored/nightward/actions/workflows/ci.yml)
 [![Nightward Policy](https://github.com/JSONbored/nightward/actions/workflows/nightward-policy.yml/badge.svg)](https://github.com/JSONbored/nightward/actions/workflows/nightward-policy.yml)
 [![OpenSSF Scorecard](https://github.com/JSONbored/nightward/actions/workflows/scorecard.yml/badge.svg)](https://github.com/JSONbored/nightward/actions/workflows/scorecard.yml)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12713/badge)](https://www.bestpractices.dev/projects/12713)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 Nightward is a local-first TUI and CLI for auditing AI agent and devtool state before it leaks into dotfiles.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,6 +23,8 @@ Open a private security advisory through [GitHub Security Advisories](https://gi
 
 Do not include real tokens, auth files, private MCP configs, or personal paths in reports. Redact values and keep only the minimum config shape needed to reproduce the issue.
 
+Maintainers aim to acknowledge vulnerability reports within 14 days. If no public response is appropriate, acknowledgement may happen privately in the GitHub Security Advisory thread.
+
 ## What Counts
 
 - Secret value disclosure in any output surface.


### PR DESCRIPTION
## Summary
- add the real OpenSSF Best Practices badge for project 12713 to the README
- document a 14-day vulnerability-report acknowledgement target in SECURITY.md

## What changed
- README now links to `https://www.bestpractices.dev/projects/12713`
- SECURITY.md now states maintainers aim to acknowledge vulnerability reports within 14 days

## Why
This records the OpenSSF Best Practices badge project now that it exists and supports the remaining OpenSSF/Scorecard posture work.

## Validation
- `trunk check --show-existing README.md SECURITY.md`

## Notes
- The local signed commit attempt failed because the signing agent refused the operation, so this docs-only commit was created unsigned.
