### PR TITLE
ci(security): harden openssf silver posture

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,20 +10,24 @@
 
 ## Safety
 
+- [ ] Every non-merge commit includes a DCO `Signed-off-by:` line.
 - [ ] No agent config mutation was added outside an explicit apply/write path.
 - [ ] New output surfaces redact secret values.
 - [ ] New adapters classify portable, machine-local, secret-auth, runtime-cache, app-owned, or unknown state.
 - [ ] Workflow changes use least-privilege permissions and pinned third-party actions.
+- [ ] Maintainer PRs received human review, or an emergency/admin exception is explained below.
 
 ## Validation
 
 - [ ] `go test ./...`
+- [ ] `make coverage-check`
 - [ ] `make test-junit`
 - [ ] `make trunk-flaky-validate`
 - [ ] `trunk check --show-existing --all`
 - [ ] `make gitleaks`
 - [ ] `make govulncheck`
 - [ ] `make fuzz-smoke`
+- [ ] `make release-snapshot` when release/build behavior changed
 
 ## Notes
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,36 @@ jobs:
         run: npm run build
         working-directory: integrations/raycast
 
+  npm-package:
+    name: NPM package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: packages/npm/package-lock.json
+
+      - name: Install npm package dependencies
+        run: npm ci --ignore-scripts --no-audit
+        working-directory: packages/npm
+
+      - name: Test npm launcher
+        run: npm test
+        working-directory: packages/npm
+
+      - name: Audit npm launcher dependencies
+        run: npm audit --audit-level=moderate
+        working-directory: packages/npm
+
+      - name: Dry-run npm package
+        run: npm run pack:dry-run
+        working-directory: packages/npm
+
   gitleaks:
     name: Secret scan
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,6 @@ on:
 permissions:
   contents: read
 
-env:
-  TRUNK_ORG_URL_SLUG: ${{ secrets.TRUNK_ORG_URL_SLUG }}
-  TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
-
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -49,9 +45,26 @@ jobs:
         run: |
           python3 -c 'import pathlib, sys, xml.etree.ElementTree as ET; report=pathlib.Path("reports/go-tests.xml"); (report.exists() or (print("missing reports/go-tests.xml", file=sys.stderr), sys.exit(1))); root=ET.parse(report).getroot(); (root.tag in {"testsuite", "testsuites"} or (print(f"unexpected JUnit root: {root.tag}", file=sys.stderr), sys.exit(1))); cases=root.findall(".//testcase"); (cases or (print("JUnit report contains no test cases", file=sys.stderr), sys.exit(1))); print(f"validated {len(cases)} JUnit test cases")'
 
+      - name: Check Trunk Flaky Tests upload credentials
+        id: trunk-flaky
+        if: ${{ always() }}
+        env:
+          TRUNK_ORG_URL_SLUG: ${{ secrets.TRUNK_ORG_URL_SLUG }}
+          TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${TRUNK_ORG_URL_SLUG}" && -n "${TRUNK_API_TOKEN}" ]]; then
+            echo "enabled=true" >>"${GITHUB_OUTPUT}"
+          else
+            echo "enabled=false" >>"${GITHUB_OUTPUT}"
+          fi
+
       - name: Upload Trunk Flaky Tests report
-        if: ${{ always() && env.TRUNK_ORG_URL_SLUG != '' && env.TRUNK_API_TOKEN != '' }}
+        if: ${{ always() && steps.trunk-flaky.outputs.enabled == 'true' }}
         uses: trunk-io/analytics-uploader@95a0fb8b29e45b6068304261fb518644b426a803 # v2.0.8
+        env:
+          TRUNK_ORG_URL_SLUG: ${{ secrets.TRUNK_ORG_URL_SLUG }}
+          TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
         with:
           junit-paths: reports/go-tests.xml
           org-slug: ${{ env.TRUNK_ORG_URL_SLUG }}
@@ -79,6 +92,18 @@ jobs:
       - name: Fuzz smoke
         run: make fuzz-smoke
 
+      - name: Coverage gate
+        run: make coverage-check
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: go-coverage
+          path: |
+            reports/coverage.out
+            reports/coverage.txt
+          if-no-files-found: error
+
   trunk:
     name: Trunk Check
     runs-on: ubuntu-latest
@@ -87,11 +112,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Trunk
-        run: |
-          set -euo pipefail
-          curl -fsSLo /tmp/trunk https://trunk.io/releases/trunk
-          chmod +x /tmp/trunk
-          sudo mv /tmp/trunk /usr/local/bin/trunk
+        run: sudo TRUNK_VERSION=1.25.0 bash scripts/install-trunk-ci.sh
 
       - name: Run Trunk Check
         run: trunk check --show-existing --all --no-fix
@@ -133,9 +154,26 @@ jobs:
         run: |
           python3 -c 'import pathlib, sys, xml.etree.ElementTree as ET; report=pathlib.Path("reports/junit/raycast.xml"); (report.exists() or (print("missing reports/junit/raycast.xml", file=sys.stderr), sys.exit(1))); root=ET.parse(report).getroot(); (root.tag in {"testsuite", "testsuites"} or (print(f"unexpected JUnit root: {root.tag}", file=sys.stderr), sys.exit(1))); cases=root.findall(".//testcase"); (cases or (print("JUnit report contains no test cases", file=sys.stderr), sys.exit(1))); print(f"validated {len(cases)} JUnit test cases")'
 
+      - name: Check Raycast Trunk Flaky Tests upload credentials
+        id: trunk-flaky
+        if: ${{ always() }}
+        env:
+          TRUNK_ORG_URL_SLUG: ${{ secrets.TRUNK_ORG_URL_SLUG }}
+          TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${TRUNK_ORG_URL_SLUG}" && -n "${TRUNK_API_TOKEN}" ]]; then
+            echo "enabled=true" >>"${GITHUB_OUTPUT}"
+          else
+            echo "enabled=false" >>"${GITHUB_OUTPUT}"
+          fi
+
       - name: Upload Raycast Trunk Flaky Tests report
-        if: ${{ always() && env.TRUNK_ORG_URL_SLUG != '' && env.TRUNK_API_TOKEN != '' }}
+        if: ${{ always() && steps.trunk-flaky.outputs.enabled == 'true' }}
         uses: trunk-io/analytics-uploader@95a0fb8b29e45b6068304261fb518644b426a803 # v2.0.8
+        env:
+          TRUNK_ORG_URL_SLUG: ${{ secrets.TRUNK_ORG_URL_SLUG }}
+          TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
         with:
           junit-paths: reports/junit/raycast.xml
           org-slug: ${{ env.TRUNK_ORG_URL_SLUG }}
@@ -207,3 +245,39 @@ jobs:
           scan-args: |-
             --recursive
             ./
+
+  dco:
+    name: DCO sign-off
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check DCO sign-offs
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bash scripts/check-dco.sh "${BASE_SHA}" "${HEAD_SHA}"
+
+  release-snapshot:
+    name: Release snapshot
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run GoReleaser snapshot
+        run: make release-snapshot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,3 +53,44 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  npm:
+    name: NPM package
+    runs-on: ubuntu-latest
+    needs: release
+    if: ${{ vars.NPM_PUBLISH == 'true' }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: npm
+          cache-dependency-path: packages/npm/package-lock.json
+
+      - name: Prepare npm package version
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${REF_NAME#v}"
+          cd packages/npm
+          npm ci --ignore-scripts --no-audit
+          npm version --no-git-tag-version "${version}"
+          npm test
+          npm audit --audit-level=moderate
+          npm pack --dry-run
+
+      - name: Publish npm package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance
+        working-directory: packages/npm

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -2,6 +2,7 @@ name: OpenSSF Scorecard
 
 on:
   branch_protection_rule:
+  pull_request:
   push:
     branches:
       - main
@@ -38,9 +39,10 @@ jobs:
         with:
           results_file: scorecard.sarif
           results_format: sarif
-          publish_results: true
+          publish_results: ${{ github.event_name != 'pull_request' }}
 
       - name: Upload SARIF
+        if: ${{ github.event_name != 'pull_request' }}
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           sarif_file: scorecard.sarif

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,7 +34,7 @@ builds:
 
 archives:
   - id: default
-    builds:
+    ids:
       - nightward
       - nw
     formats:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,8 @@
 Nightward uses Conventional Commit-style PR titles so release notes stay readable.
 
 Formal changelog entries begin with the first tagged release.
+
+## Unreleased
+
+- Replaced pre-1.0 deterministic SHA-1 IDs with SHA-256-backed IDs while preserving the short ID shape.
+- Added OpenSSF Silver-ready governance, threat model, DCO, coverage, and release snapshot hardening.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@ Formal changelog entries begin with the first tagged release.
 
 - Replaced pre-1.0 deterministic SHA-1 IDs with SHA-256-backed IDs while preserving the short ID shape.
 - Added OpenSSF Silver-ready governance, threat model, DCO, coverage, and release snapshot hardening.
+- Added a release-gated npm launcher package that downloads GitHub Release binaries on first run without `postinstall`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,17 @@ Use fixtures with temporary homes for adapter and policy tests. Do not add real 
 - Any new output surface must preserve redaction.
 - New adapters need classification, risk rationale, and no-write tests when practical.
 - MCP/security rules need fixture coverage and a safe remediation posture.
+- Major user-facing, security, parser, policy, adapter, and output changes need tests or a documented reason in the PR.
+
+## Developer Certificate Of Origin
+
+Nightward uses the Developer Certificate of Origin (DCO) for contributions. Every non-merge commit in a pull request must include a sign-off line:
+
+```text
+Signed-off-by: Name <email@example.com>
+```
+
+Use `git commit -s` for new commits, or `git commit --amend -s --no-edit` to add the sign-off to the latest commit. The sign-off means you certify that you have the right to submit the contribution under the project license.
 
 ## CI And Action Pinning
 
@@ -55,3 +66,5 @@ Use focused PRs. A good PR explains:
 - what user-facing behavior changed
 - what was validated
 - any remaining risk or follow-up
+
+Maintainer-authored changes should still flow through pull requests and human review unless there is an emergency security fix or repository administration task that cannot wait. Emergency exceptions should be documented after the fact.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,35 @@
+# Governance
+
+Nightward is maintained as a small, security-sensitive open source project. The project favors local custody, explicit user consent, and conservative defaults over broad automation.
+
+## Decision Making
+
+Maintainers make decisions in public issues and pull requests when practical. Security-sensitive reports may be handled privately through GitHub Security Advisories until disclosure is safe.
+
+Project changes should preserve these boundaries:
+
+- no telemetry
+- no default network calls
+- no live agent-config mutation without an explicit future apply workflow
+- no secret values in reports, SARIF, TUI, Raycast, or docs examples
+- reviewed, reasoned exceptions for policy suppressions
+
+## Roles
+
+- Maintainers review and merge changes, manage releases, triage security reports, and protect project boundaries.
+- Contributors propose code, docs, tests, adapters, and issue reports through GitHub.
+- Security reporters may use private advisories for sensitive issues.
+
+## Review Policy
+
+Normal changes should land through pull requests with CI passing and human review. Maintainer-authored changes are not exempt from review once additional maintainers are available. Emergency security or repository administration exceptions should be documented after merge.
+
+## Access Continuity
+
+At least one maintainer must retain admin access to the GitHub repository, release configuration, OpenSSF badge entry, and package publishing surfaces. Additional maintainers should be added only after a history of useful, security-aware contributions.
+
+Maintainers are expected to use 2FA on GitHub and protect signing, release, and package credentials.
+
+## Scope Changes
+
+Large scope changes, especially anything involving config mutation, restore, sync, online providers, or hosted services, should start as an issue or design note before implementation.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,28 @@
+# Maintainers
+
+Current maintainer:
+
+- [@JSONbored](https://github.com/JSONbored)
+
+## Maintainer Expectations
+
+- Keep GitHub 2FA enabled.
+- Use pull requests and human review for normal changes.
+- Keep CI, CodeQL, Nightward Policy, OpenSSF Scorecard, Gitleaks, govulncheck, OSV, and Trunk checks healthy.
+- Keep release tags intentional, signed where practical, and tied to human-readable release notes.
+- Treat reports that include private paths, credentials, or agent state as sensitive.
+
+## Adding Maintainers
+
+New maintainers should demonstrate:
+
+- repeated high-quality contributions
+- comfort with Nightward's redaction and no-write boundaries
+- security-aware review habits
+- willingness to review others' pull requests
+
+Adding a maintainer should be recorded in a pull request updating this file.
+
+## Succession
+
+If the current maintainer becomes unavailable, trusted maintainers should preserve user safety first: keep releases paused until CI, security reporting, and artifact signing remain under control.

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,14 @@ GITLEAKS_VERSION ?= v8.30.1
 GOVULNCHECK_VERSION ?= v1.3.0
 GOSEC_VERSION ?= v2.26.1
 STATICCHECK_VERSION ?= v0.7.0
+GORELEASER_VERSION ?= v2.9.0
+SYFT_VERSION ?= v1.43.0
+COVERAGE_THRESHOLD ?= 80.0
 RAYCAST_DIR ?= integrations/raycast
 GO_PACKAGES ?= $(shell go list ./cmd/... ./internal/... ./tools/...)
+COVERAGE_PACKAGES ?= ./internal/...
 
-.PHONY: test test-race vet staticcheck gosec gitleaks govulncheck fuzz-smoke go-test-junit test-junit trunk-check trunk-fix trunk-flaky-validate raycast-install raycast-test raycast-test-junit raycast-audit raycast-lint raycast-build raycast-verify verify build install-local clean-reports
+.PHONY: test test-race vet staticcheck gosec gitleaks govulncheck fuzz-smoke coverage coverage-check go-test-junit test-junit trunk-check trunk-fix trunk-flaky-validate ci-scripts-test raycast-install raycast-test raycast-test-junit raycast-audit raycast-lint raycast-build raycast-verify tool-syft release-snapshot verify build install-local clean-reports
 
 test:
 	go test $(GO_PACKAGES)
@@ -34,6 +38,17 @@ govulncheck:
 fuzz-smoke:
 	go test ./internal/inventory -run=^$$ -fuzz=FuzzMCPConfigParsing -fuzztime=10s
 
+coverage:
+	mkdir -p $(REPORTS_DIR)
+	go test $(COVERAGE_PACKAGES) -coverprofile=$(REPORTS_DIR)/coverage.out
+	go tool cover -func=$(REPORTS_DIR)/coverage.out | tee $(REPORTS_DIR)/coverage.txt
+
+coverage-check:
+	mkdir -p $(REPORTS_DIR)
+	go test $(COVERAGE_PACKAGES) -coverprofile=$(REPORTS_DIR)/coverage.out
+	go tool cover -func=$(REPORTS_DIR)/coverage.out | tee $(REPORTS_DIR)/coverage.txt
+	python3 -c 'import pathlib, re, sys; text=pathlib.Path("$(REPORTS_DIR)/coverage.txt").read_text(); match=re.search(r"total:\s+\(statements\)\s+([0-9.]+)%", text); pct=float(match.group(1)) if match else -1; threshold=float("$(COVERAGE_THRESHOLD)"); print(f"coverage {pct:.1f}% / threshold {threshold:.1f}%"); sys.exit(0 if pct >= threshold else 1)'
+
 go-test-junit:
 	mkdir -p $(REPORTS_DIR)
 	go run gotest.tools/gotestsum@$(GOTESTSUM_VERSION) --format testname --junitfile $(REPORTS_DIR)/go-tests.raw.xml -- $(GO_PACKAGES)
@@ -50,6 +65,10 @@ trunk-fix:
 
 trunk-flaky-validate:
 	trunk flakytests validate --junit-paths $(REPORTS_DIR)/go-tests.xml,$(REPORTS_DIR)/junit/raycast.xml
+
+ci-scripts-test:
+	bash scripts/test-dco.sh
+	bash scripts/test-action-paths.sh
 
 raycast-install:
 	cd $(RAYCAST_DIR) && npm ci --ignore-scripts --no-audit
@@ -71,7 +90,13 @@ raycast-build:
 
 raycast-verify: raycast-install raycast-test raycast-audit raycast-lint raycast-build
 
-verify: test test-race vet staticcheck gosec gitleaks govulncheck fuzz-smoke test-junit trunk-flaky-validate trunk-check raycast-audit raycast-lint raycast-build
+tool-syft:
+	go install github.com/anchore/syft/cmd/syft@$(SYFT_VERSION)
+
+release-snapshot: tool-syft
+	PATH="$$(go env GOPATH)/bin:$$PATH" go run github.com/goreleaser/goreleaser/v2@$(GORELEASER_VERSION) release --snapshot --clean --skip=publish,sign
+
+verify: test test-race vet staticcheck gosec gitleaks govulncheck fuzz-smoke coverage-check test-junit trunk-flaky-validate trunk-check ci-scripts-test raycast-audit raycast-lint raycast-build
 
 build:
 	go build -o bin/nightward ./cmd/nightward

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,11 @@ GORELEASER_VERSION ?= v2.9.0
 SYFT_VERSION ?= v1.43.0
 COVERAGE_THRESHOLD ?= 80.0
 RAYCAST_DIR ?= integrations/raycast
+NPM_PACKAGE_DIR ?= packages/npm
 GO_PACKAGES ?= $(shell go list ./cmd/... ./internal/... ./tools/...)
 COVERAGE_PACKAGES ?= ./internal/...
 
-.PHONY: test test-race vet staticcheck gosec gitleaks govulncheck fuzz-smoke coverage coverage-check go-test-junit test-junit trunk-check trunk-fix trunk-flaky-validate ci-scripts-test raycast-install raycast-test raycast-test-junit raycast-audit raycast-lint raycast-build raycast-verify tool-syft release-snapshot verify build install-local clean-reports
+.PHONY: test test-race vet staticcheck gosec gitleaks govulncheck fuzz-smoke coverage coverage-check go-test-junit test-junit trunk-check trunk-fix trunk-flaky-validate ci-scripts-test raycast-install raycast-test raycast-test-junit raycast-audit raycast-lint raycast-build raycast-verify npm-package-install npm-package-test npm-package-audit npm-package-pack npm-package-verify tool-syft release-snapshot verify build install-local clean-reports
 
 test:
 	go test $(GO_PACKAGES)
@@ -90,13 +91,27 @@ raycast-build:
 
 raycast-verify: raycast-install raycast-test raycast-audit raycast-lint raycast-build
 
+npm-package-install:
+	cd $(NPM_PACKAGE_DIR) && npm ci --ignore-scripts --no-audit
+
+npm-package-test:
+	cd $(NPM_PACKAGE_DIR) && npm test
+
+npm-package-audit:
+	cd $(NPM_PACKAGE_DIR) && npm audit --audit-level=moderate
+
+npm-package-pack:
+	cd $(NPM_PACKAGE_DIR) && npm run pack:dry-run
+
+npm-package-verify: npm-package-install npm-package-test npm-package-audit npm-package-pack
+
 tool-syft:
 	go install github.com/anchore/syft/cmd/syft@$(SYFT_VERSION)
 
 release-snapshot: tool-syft
 	PATH="$$(go env GOPATH)/bin:$$PATH" go run github.com/goreleaser/goreleaser/v2@$(GORELEASER_VERSION) release --snapshot --clean --skip=publish,sign
 
-verify: test test-race vet staticcheck gosec gitleaks govulncheck fuzz-smoke coverage-check test-junit trunk-flaky-validate trunk-check ci-scripts-test raycast-audit raycast-lint raycast-build
+verify: test test-race vet staticcheck gosec gitleaks govulncheck fuzz-smoke coverage-check test-junit trunk-flaky-validate trunk-check ci-scripts-test raycast-audit raycast-lint raycast-build npm-package-verify
 
 build:
 	go build -o bin/nightward ./cmd/nightward

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Nightward answers the practical questions first:
 - Read-only Raycast extension for Dashboard, Findings, Analysis, Provider Doctor, Explain Finding/Signal, Fix Plan/Analysis export, and report-folder access.
 - User-level nightly scan scheduling for macOS launchd, Linux systemd user timers, and cron text fallback.
 - No telemetry, no cloud dashboard, no network calls from Nightward runtime, and no live config mutation.
+- OpenSSF-oriented project hygiene: DCO, governance docs, threat model, coverage gate, pinned CI actions, release snapshot checks, signed release configuration, and security reporting policy.
 
 > [!TIP]
 > A practical first pass is `nw doctor --json`, then `nw scan --json`, then `nw fix plan --all --json`.
@@ -343,9 +344,12 @@ Scheduled scans never copy secrets, mutate dotfiles, restore files, or push to G
 make test
 make test-race
 make test-junit
+make coverage-check
 make trunk-flaky-validate
 make trunk-check
+make ci-scripts-test
 make raycast-verify
+make release-snapshot
 make verify
 go run ./cmd/nightward --help
 go run ./cmd/nw --help
@@ -370,11 +374,15 @@ trunk check --show-existing --all
 make gitleaks
 make govulncheck
 make fuzz-smoke
+make coverage-check
+make release-snapshot
 ```
 
 ## Project Docs
 
 - [Security policy](SECURITY.md)
+- [Governance](GOVERNANCE.md)
+- [Maintainers](MAINTAINERS.md)
 - [Contributing guide](CONTRIBUTING.md)
 - [Code of conduct](CODE_OF_CONDUCT.md)
 - [Support](SUPPORT.md)
@@ -387,6 +395,8 @@ make fuzz-smoke
 - [GitHub Action](docs/action.md)
 - [Raycast extension](docs/raycast-extension.md)
 - [CI/security notes](docs/ci-security.md)
+- [Threat model](docs/threat-model.md)
+- [OpenSSF evidence](docs/openssf-best-practices.md)
 - [Privacy model](docs/privacy-model.md)
 - [Screenshot/GIF capture plan](docs/screenshots.md)
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ This installs:
 - `nightward`: canonical project command
 - `nw`: short alias for frequent terminal/TUI use
 
+After the first tagged release, Nightward will also ship a release-gated npm launcher:
+
+```sh
+npx nightward --help
+npm install -g nightward
+nw scan --json
+```
+
+The npm package is intentionally a thin launcher for GitHub Release binaries. It does not run a `postinstall` script; on first execution it downloads the matching release archive, verifies the archive SHA-256 from `checksums.txt`, caches the binaries locally, and then runs `nightward` or `nw`.
+
 ## Quick Start
 
 Open the TUI:
@@ -349,6 +359,7 @@ make trunk-flaky-validate
 make trunk-check
 make ci-scripts-test
 make raycast-verify
+make npm-package-verify
 make release-snapshot
 make verify
 go run ./cmd/nightward --help
@@ -387,6 +398,7 @@ make release-snapshot
 - [Code of conduct](CODE_OF_CONDUCT.md)
 - [Support](SUPPORT.md)
 - [Roadmap](ROADMAP.md)
+- [Install and release channels](docs/install.md)
 - [Adapters](docs/adapters.md)
 - [Analysis](docs/analysis.md)
 - [Remediation](docs/remediation.md)
@@ -395,6 +407,7 @@ make release-snapshot
 - [GitHub Action](docs/action.md)
 - [Raycast extension](docs/raycast-extension.md)
 - [CI/security notes](docs/ci-security.md)
+- [Release process](docs/release.md)
 - [Threat model](docs/threat-model.md)
 - [OpenSSF evidence](docs/openssf-best-practices.md)
 - [Privacy model](docs/privacy-model.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,6 +13,7 @@ Nightward is intentionally staged. The scanner and policy model need to stay tru
 - Read-only snapshot plan and diff commands.
 - SARIF and policy output for CI.
 - GitHub Action wrapper for repository policy checks.
+- Release-gated npm launcher package with checksum verification and no postinstall.
 - Read-only Raycast extension for scan summaries, findings, redacted fix-plan export, and report-folder access.
 - User-level nightly schedule generation.
 - Trunk Check and Trunk Flaky Tests JUnit validation.
@@ -25,8 +26,7 @@ Nightward is intentionally staged. The scanner and policy model need to stay tru
 - Bubble Tea/Bubbles TUI upgrade with list, table, viewport, textinput, help, filter modal, command palette, report history, and mouse-wheel support.
 - Optional provider execution for local scanners with timeouts, file-size caps, redaction, and explicit online-provider opt-in.
 - Fuzz coverage for MCP JSON/TOML/YAML parsing, URL/header redaction, symlink traversal, huge files, and malformed configs.
-- Validate GoReleaser on the first release candidate tag.
-- Add SLSA provenance/attestation after the first release snapshot and signed checksum flow are stable.
+- Add SLSA provenance/attestation after signed checksum and npm provenance flow are stable.
 - Screenshot and GIF assets for the README.
 
 ## Later

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,8 +25,8 @@ Nightward is intentionally staged. The scanner and policy model need to stay tru
 - Bubble Tea/Bubbles TUI upgrade with list, table, viewport, textinput, help, filter modal, command palette, report history, and mouse-wheel support.
 - Optional provider execution for local scanners with timeouts, file-size caps, redaction, and explicit online-provider opt-in.
 - Fuzz coverage for MCP JSON/TOML/YAML parsing, URL/header redaction, symlink traversal, huge files, and malformed configs.
-- Threat model documentation for provider execution, report exports, scheduler behavior, and SARIF uploads.
 - Validate GoReleaser on the first release candidate tag.
+- Add SLSA provenance/attestation after the first release snapshot and signed checksum flow are stable.
 - Screenshot and GIF assets for the README.
 
 ## Later

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,19 @@ Do not include real tokens, auth files, private MCP configs, or personal paths i
 
 Maintainers aim to acknowledge vulnerability reports within 14 days. If no public response is appropriate, acknowledgement may happen privately in the GitHub Security Advisory thread.
 
+## Vulnerability Handling
+
+Maintainers triage reports by practical impact:
+
+- Critical: secret disclosure, unsafe write/default mutation, release compromise, or exploitable code execution.
+- High: reliable policy bypass, redaction failure in a common output path, or CI behavior that could publish untrusted artifacts.
+- Medium: parser misclassification, unsafe remediation guidance, or denial-of-service through malformed local config.
+- Low: documentation gaps, unclear warnings, or hardening improvements without direct exploitability.
+
+Confirmed vulnerabilities are tracked privately until a fix is ready or disclosure is safe. Fixes should include regression tests for the affected output surface, parser shape, or workflow path. Release notes must call out publicly known project vulnerabilities that had a CVE, GHSA, or similar public identifier when the release was created.
+
+Reporters may be credited in release notes or advisories unless they request otherwise. Nightward does not pay bug bounties.
+
 ## What Counts
 
 - Secret value disclosure in any output surface.
@@ -32,3 +45,7 @@ Maintainers aim to acknowledge vulnerability reports within 14 days. If no publi
 - Unsafe remediation guidance that would leak credentials or broaden permissions.
 - CI/release workflow behavior that could let untrusted code publish artifacts.
 - Parser behavior that misclassifies known high-risk MCP config as safe.
+
+## Threat Model
+
+The active threat model is maintained in [docs/threat-model.md](docs/threat-model.md).

--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,16 @@ runs:
 
         config_args=()
         if [[ -n "${config}" ]]; then
-          config_args+=(--config "${config}")
+          bash "${GITHUB_ACTION_PATH}/scripts/validate-action-path.sh" config "${config}"
+          config_args+=(--config "${GITHUB_WORKSPACE}/${config}")
+        fi
+        bash "${GITHUB_ACTION_PATH}/scripts/validate-action-path.sh" output "${output}"
+        output_path="${GITHUB_WORKSPACE}/${output}"
+        summary_path="${output_path}"
+        if [[ "${output}" == "-" ]]; then
+          summary_path="${GITHUB_WORKSPACE}/nightward-output.json"
+        else
+          mkdir -p "$(dirname "${output_path}")"
         fi
         workspace_args=()
         if [[ -n "${scan_workspace}" ]]; then
@@ -94,8 +103,14 @@ runs:
         cd "${GITHUB_ACTION_PATH}"
         case "${mode}" in
           scan)
-            go run ./cmd/nw scan "${workspace_args[@]}" --json --output "${GITHUB_WORKSPACE}/${output}"
-            echo "output=${output}" >>"${GITHUB_OUTPUT}"
+            if [[ "${output}" == "-" ]]; then
+              go run ./cmd/nw scan "${workspace_args[@]}" --json --output - >"${summary_path}"
+              echo "output=nightward-output.json" >>"${GITHUB_OUTPUT}"
+            else
+              go run ./cmd/nw scan "${workspace_args[@]}" --json --output "${output_path}"
+              echo "output=${output}" >>"${GITHUB_OUTPUT}"
+            fi
+            echo "output-path=${summary_path}" >>"${GITHUB_OUTPUT}"
             ;;
           policy)
             args=(policy check "${config_args[@]}" "${workspace_args[@]}" "${analysis_args[@]}" --json)
@@ -108,10 +123,17 @@ runs:
             set -e
             echo "policy-exit-code=${policy_exit}" >>"${GITHUB_OUTPUT}"
             echo "output=nightward-policy.json" >>"${GITHUB_OUTPUT}"
+            echo "output-path=${GITHUB_WORKSPACE}/nightward-policy.json" >>"${GITHUB_OUTPUT}"
             ;;
           sarif)
-            go run ./cmd/nw policy sarif "${config_args[@]}" "${workspace_args[@]}" "${analysis_args[@]}" --output "${GITHUB_WORKSPACE}/${output}"
-            echo "output=${output}" >>"${GITHUB_OUTPUT}"
+            if [[ "${output}" == "-" ]]; then
+              go run ./cmd/nw policy sarif "${config_args[@]}" "${workspace_args[@]}" "${analysis_args[@]}" --output - >"${summary_path}"
+              echo "output=nightward-output.json" >>"${GITHUB_OUTPUT}"
+            else
+              go run ./cmd/nw policy sarif "${config_args[@]}" "${workspace_args[@]}" "${analysis_args[@]}" --output "${output_path}"
+              echo "output=${output}" >>"${GITHUB_OUTPUT}"
+            fi
+            echo "output-path=${summary_path}" >>"${GITHUB_OUTPUT}"
             ;;
           *)
             echo "unsupported mode: ${mode}" >&2
@@ -130,13 +152,13 @@ runs:
 
         case "${INPUT_MODE}" in
           scan)
-            python3 -c 'import json, sys; data=json.load(open(sys.argv[1], encoding="utf-8")); print("findings-count=%s" % data.get("summary", {}).get("total_findings", 0)); print("policy-passed=")' "${GITHUB_WORKSPACE}/${INPUT_OUTPUT}" >>"${GITHUB_OUTPUT}"
+            python3 -c 'import json, sys; data=json.load(open(sys.argv[1], encoding="utf-8")); print("findings-count=%s" % data.get("summary", {}).get("total_findings", 0)); print("policy-passed=")' "${{ steps.run-nightward.outputs.output-path }}" >>"${GITHUB_OUTPUT}"
             ;;
           policy)
-            python3 -c 'import json, sys; data=json.load(open(sys.argv[1], encoding="utf-8")); print("findings-count=%s" % data.get("summary", {}).get("total_findings", 0)); print("policy-passed=%s" % str(data.get("passed", False)).lower())' "${GITHUB_WORKSPACE}/nightward-policy.json" >>"${GITHUB_OUTPUT}"
+            python3 -c 'import json, sys; data=json.load(open(sys.argv[1], encoding="utf-8")); print("findings-count=%s" % data.get("summary", {}).get("total_findings", 0)); print("policy-passed=%s" % str(data.get("passed", False)).lower())' "${{ steps.run-nightward.outputs.output-path }}" >>"${GITHUB_OUTPUT}"
             ;;
           sarif)
-            python3 -c 'import json, sys; data=json.load(open(sys.argv[1], encoding="utf-8")); count=sum(len(run.get("results", [])) for run in data.get("runs", [])); print(f"findings-count={count}"); print("policy-passed=")' "${GITHUB_WORKSPACE}/${INPUT_OUTPUT}" >>"${GITHUB_OUTPUT}"
+            python3 -c 'import json, sys; data=json.load(open(sys.argv[1], encoding="utf-8")); count=sum(len(run.get("results", [])) for run in data.get("runs", [])); print(f"findings-count={count}"); print("policy-passed=")' "${{ steps.run-nightward.outputs.output-path }}" >>"${GITHUB_OUTPUT}"
             ;;
         esac
 

--- a/docs/action.md
+++ b/docs/action.md
@@ -35,6 +35,8 @@ Outputs:
 
 The action runs Nightward locally. It does not upload findings unless your workflow separately uploads artifacts or SARIF.
 
+`config` and `output` must be relative paths inside `GITHUB_WORKSPACE`. The action rejects absolute paths, parent traversal, backslashes, and newline characters before invoking Nightward.
+
 For repository CI, prefer workspace mode:
 
 ```yaml

--- a/docs/ci-security.md
+++ b/docs/ci-security.md
@@ -4,10 +4,10 @@ Nightward's CI is meant to prove the project is serious about the same safety po
 
 ## Workflows
 
-- `ci.yml`: Go tests, race tests, `go vet`, `staticcheck`, `gosec`, fuzz smoke tests, JUnit reports, local JUnit shape validation, gated Trunk Flaky Tests uploads, explicit Trunk Check CLI execution, Raycast extension tests/build/audit, Gitleaks, govulncheck, and OSV dependency scanning.
+- `ci.yml`: Go tests, race tests, coverage gate, `go vet`, `staticcheck`, `gosec`, fuzz smoke tests, JUnit reports, local JUnit shape validation, gated Trunk Flaky Tests uploads, explicit Trunk Check CLI execution, Raycast extension tests/build/audit, Gitleaks, govulncheck, OSV dependency scanning, DCO checking, and GoReleaser snapshot validation.
 - `nightward-policy.yml`: generates workspace Nightward SARIF and uploads it to GitHub code scanning without scanning synthetic risky fixture homes.
 - `plugin.yaml`: defines Trunk Check linters for workspace policy and analysis SARIF once release tags are available.
-- `scorecard.yml`: runs OpenSSF Scorecard and uploads SARIF.
+- `scorecard.yml`: runs OpenSSF Scorecard on PRs, `main`, branch-protection changes, and a weekly schedule. PR runs do not publish results or upload SARIF; `main` and scheduled runs upload SARIF.
 - `release.yml`: publishes signed GoReleaser artifacts from strict `vX.Y.Z` tags.
 - `renovate.json`: manages Go modules, Raycast npm packages, pinned GitHub Actions, local tool pins, and release tooling updates.
 
@@ -24,6 +24,10 @@ Nightward's CI is meant to prove the project is serious about the same safety po
 - Use Renovate instead of Dependabot whenever possible.
 - Keep dependency PRs reviewed; do not enable broad automerge by default.
 - Use repo-controlled `make gitleaks` and `make govulncheck` targets in CI so local and remote behavior match.
+- Install Trunk in CI from a pinned release archive with a checked SHA-256 instead of a moving launcher URL.
+- Keep Trunk Flaky Tests secrets scoped to the detection/upload steps only.
+- Keep composite action output/config paths relative to `GITHUB_WORKSPACE`; reject absolute paths, parent traversal, and newlines.
+- Require DCO sign-offs on pull request commits.
 
 ## Trunk Plugin Notes
 

--- a/docs/ci-security.md
+++ b/docs/ci-security.md
@@ -4,11 +4,11 @@ Nightward's CI is meant to prove the project is serious about the same safety po
 
 ## Workflows
 
-- `ci.yml`: Go tests, race tests, coverage gate, `go vet`, `staticcheck`, `gosec`, fuzz smoke tests, JUnit reports, local JUnit shape validation, gated Trunk Flaky Tests uploads, explicit Trunk Check CLI execution, Raycast extension tests/build/audit, Gitleaks, govulncheck, OSV dependency scanning, DCO checking, and GoReleaser snapshot validation.
+- `ci.yml`: Go tests, race tests, coverage gate, `go vet`, `staticcheck`, `gosec`, fuzz smoke tests, JUnit reports, local JUnit shape validation, gated Trunk Flaky Tests uploads, explicit Trunk Check CLI execution, Raycast extension tests/build/audit, npm launcher tests/audit/package dry-run, Gitleaks, govulncheck, OSV dependency scanning, DCO checking, and GoReleaser snapshot validation.
 - `nightward-policy.yml`: generates workspace Nightward SARIF and uploads it to GitHub code scanning without scanning synthetic risky fixture homes.
 - `plugin.yaml`: defines Trunk Check linters for workspace policy and analysis SARIF once release tags are available.
 - `scorecard.yml`: runs OpenSSF Scorecard on PRs, `main`, branch-protection changes, and a weekly schedule. PR runs do not publish results or upload SARIF; `main` and scheduled runs upload SARIF.
-- `release.yml`: publishes signed GoReleaser artifacts from strict `vX.Y.Z` tags.
+- `release.yml`: publishes signed GoReleaser artifacts from strict `vX.Y.Z` tags and can publish the npm launcher only when explicitly enabled.
 - `renovate.json`: manages Go modules, Raycast npm packages, pinned GitHub Actions, local tool pins, and release tooling updates.
 
 ## Action Policy
@@ -28,6 +28,7 @@ Nightward's CI is meant to prove the project is serious about the same safety po
 - Keep Trunk Flaky Tests secrets scoped to the detection/upload steps only.
 - Keep composite action output/config paths relative to `GITHUB_WORKSPACE`; reject absolute paths, parent traversal, and newlines.
 - Require DCO sign-offs on pull request commits.
+- Keep the npm package free of `postinstall`; publish only from reviewed tags with provenance.
 
 ## Trunk Plugin Notes
 
@@ -45,6 +46,5 @@ trunk check enable nightward-policy
 
 ## Release Hardening Backlog
 
-- Validate GoReleaser on the first release candidate tag.
 - Add provenance once release artifact flow is stable.
 - Defer Homebrew tap automation until the first tagged release.

--- a/docs/dependency-maintenance.md
+++ b/docs/dependency-maintenance.md
@@ -7,7 +7,7 @@ Nightward uses Renovate instead of Dependabot.
 - Go modules in `go.mod` and `go.sum`.
 - Raycast extension packages in `integrations/raycast/package.json` and `package-lock.json`.
 - GitHub Actions versions and pinned action digests.
-- `gotestsum`, `gitleaks`, and `govulncheck` pins in `Makefile`.
+- `gotestsum`, `gitleaks`, `govulncheck`, `gosec`, `staticcheck`, GoReleaser, and Syft pins in `Makefile`.
 - GoReleaser binary version in `.github/workflows/release.yml`.
 - Trunk plugin registry pin in `.trunk/trunk.yaml`.
 
@@ -29,3 +29,4 @@ Dependency PRs should still be reviewed like code changes. Check:
 - `go.sum` changes for unexpected transitive churn
 - `integrations/raycast/package-lock.json` changes for unexpected runtime dependency additions
 - CI results for Go tests, Raycast extension tests/build, Trunk Check, Gitleaks, govulncheck, OSV, and Nightward SARIF
+- checked SHA changes in scripts that install pinned CI tools such as Trunk

--- a/docs/dependency-maintenance.md
+++ b/docs/dependency-maintenance.md
@@ -6,6 +6,7 @@ Nightward uses Renovate instead of Dependabot.
 
 - Go modules in `go.mod` and `go.sum`.
 - Raycast extension packages in `integrations/raycast/package.json` and `package-lock.json`.
+- NPM launcher package metadata in `packages/npm/package.json` and `package-lock.json`.
 - GitHub Actions versions and pinned action digests.
 - `gotestsum`, `gitleaks`, `govulncheck`, `gosec`, `staticcheck`, GoReleaser, and Syft pins in `Makefile`.
 - GoReleaser binary version in `.github/workflows/release.yml`.
@@ -28,5 +29,6 @@ Dependency PRs should still be reviewed like code changes. Check:
 - workflow diffs for permission or publish-surface changes
 - `go.sum` changes for unexpected transitive churn
 - `integrations/raycast/package-lock.json` changes for unexpected runtime dependency additions
+- `packages/npm/package-lock.json` changes for unexpected launcher dependency additions
 - CI results for Go tests, Raycast extension tests/build, Trunk Check, Gitleaks, govulncheck, OSV, and Nightward SARIF
 - checked SHA changes in scripts that install pinned CI tools such as Trunk

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,55 @@
+# Install And Release Channels
+
+Nightward should be easy to try without weakening its security posture. The preferred release model is signed GitHub Release artifacts first, then convenience installers that point back to those artifacts.
+
+## Current Local Install
+
+```sh
+make install-local
+```
+
+This builds `nightward` and `nw` from the local checkout into `~/.local/bin` by default.
+
+## GitHub Releases
+
+After the first reviewed release tag, GitHub Releases are the canonical binary distribution channel.
+
+Release artifacts include:
+
+- `nightward` and `nw` binaries for macOS, Linux, and Windows.
+- `checksums.txt`.
+- `checksums.txt.sig` from Cosign.
+- SBOM files for release archives.
+
+Users who want the strongest supply-chain verification should download from GitHub Releases and verify the signed checksum file before installing.
+
+## NPM
+
+The `nightward` npm package name is available and this repo includes a release-gated package under `packages/npm`.
+
+The package is a thin launcher:
+
+- no `postinstall` script
+- no bundled Node implementation of Nightward
+- downloads the matching GitHub Release archive on first run
+- verifies the archive SHA-256 from `checksums.txt`
+- caches extracted `nightward` and `nw` binaries locally
+
+Example after the first release is published:
+
+```sh
+npx nightward --help
+npm install -g nightward
+nw scan --json
+```
+
+Publishing is disabled by default. The release workflow publishes to npm only when `NPM_PUBLISH=true` is configured and npm credentials/trusted publishing are ready.
+
+## Deferred Channels
+
+These are useful, but should wait until the first signed GitHub Release proves stable:
+
+- Homebrew tap
+- Nix package
+- mise/aqua registry entries
+- Docker image for report browsing

--- a/docs/openssf-best-practices.md
+++ b/docs/openssf-best-practices.md
@@ -1,0 +1,49 @@
+# OpenSSF Best Practices Evidence
+
+Nightward tracks OpenSSF Best Practices evidence here so the badge entry can be updated without hunting through the repository.
+
+Project badge: <https://www.bestpractices.dev/projects/12713>
+
+## Passing Evidence
+
+- Project website and repository: <https://github.com/JSONbored/nightward>
+- Contribution process: <https://github.com/JSONbored/nightward/blob/main/CONTRIBUTING.md>
+- Contribution requirements: <https://github.com/JSONbored/nightward/blob/main/CONTRIBUTING.md>
+- License location: <https://github.com/JSONbored/nightward/blob/main/LICENSE>
+- Documentation basics and interface docs: README plus `docs/action.md`, `docs/analysis.md`, `docs/remediation.md`, `docs/privacy-model.md`, and `docs/adapters.md`.
+- Discussion and report archive: <https://github.com/JSONbored/nightward/issues>
+- Vulnerability reporting: <https://github.com/JSONbored/nightward/blob/main/SECURITY.md>
+- Build system: `Makefile`, `go.mod`, Raycast `package-lock.json`, and GitHub Actions.
+- Tests: `make test`, `make test-race`, `make test-junit`, `make coverage-check`, `make verify`.
+- CI: `.github/workflows/ci.yml`, `.github/workflows/nightward-policy.yml`, `.github/workflows/scorecard.yml`.
+- Static analysis: `go vet`, `staticcheck`, `gosec`, Trunk Check, CodeQL, Gitleaks, govulncheck, OSV, and Nightward SARIF.
+- Dynamic analysis: automated tests, race tests, Raycast tests/build, and Go fuzz smoke tests.
+- Secret scanning: Gitleaks in CI and `make gitleaks`.
+
+## N/A Crypto Fields
+
+Nightward does not implement cryptographic protocols, encryption, password storage, key exchange, credential verification, cryptographic signing, or cryptographic key generation.
+
+The release pipeline uses external tools for signing release checksums and SBOM generation. Nightward runtime does not provide cryptographic security mechanisms.
+
+## Silver-Ready Evidence
+
+- Governance: <https://github.com/JSONbored/nightward/blob/main/GOVERNANCE.md>
+- Maintainers and access continuity: <https://github.com/JSONbored/nightward/blob/main/MAINTAINERS.md>
+- Code of conduct: <https://github.com/JSONbored/nightward/blob/main/CODE_OF_CONDUCT.md>
+- Roadmap: <https://github.com/JSONbored/nightward/blob/main/ROADMAP.md>
+- Architecture/security model: `docs/privacy-model.md`, `docs/threat-model.md`, `docs/ci-security.md`, and `docs/remediation.md`.
+- Dependency maintenance: <https://github.com/JSONbored/nightward/blob/main/docs/dependency-maintenance.md>
+- DCO: `CONTRIBUTING.md` and the CI DCO sign-off job.
+- Release readiness: `.goreleaser.yml`, `make release-snapshot`, signed checksum config, SBOM config, and release workflow.
+
+## Manual Badge Actions
+
+These cannot be completed by repository files alone:
+
+- Save the OpenSSF badge form while logged in as a maintainer.
+- Keep GitHub branch protection/rulesets requiring reviewed PRs and status checks.
+- Keep maintainer 2FA enabled.
+- Let Scorecard `Maintained` age out after the repository is older than 90 days.
+- Improve Scorecard `Code-Review` through future reviewed PR history.
+- Create the first signed release only after the release candidate is reviewed.

--- a/docs/openssf-best-practices.md
+++ b/docs/openssf-best-practices.md
@@ -13,7 +13,7 @@ Project badge: <https://www.bestpractices.dev/projects/12713>
 - Documentation basics and interface docs: README plus `docs/action.md`, `docs/analysis.md`, `docs/remediation.md`, `docs/privacy-model.md`, and `docs/adapters.md`.
 - Discussion and report archive: <https://github.com/JSONbored/nightward/issues>
 - Vulnerability reporting: <https://github.com/JSONbored/nightward/blob/main/SECURITY.md>
-- Build system: `Makefile`, `go.mod`, Raycast `package-lock.json`, and GitHub Actions.
+- Build system: `Makefile`, `go.mod`, Raycast and npm launcher `package-lock.json` files, and GitHub Actions.
 - Tests: `make test`, `make test-race`, `make test-junit`, `make coverage-check`, `make verify`.
 - CI: `.github/workflows/ci.yml`, `.github/workflows/nightward-policy.yml`, `.github/workflows/scorecard.yml`.
 - Static analysis: `go vet`, `staticcheck`, `gosec`, Trunk Check, CodeQL, Gitleaks, govulncheck, OSV, and Nightward SARIF.
@@ -35,7 +35,7 @@ The release pipeline uses external tools for signing release checksums and SBOM 
 - Architecture/security model: `docs/privacy-model.md`, `docs/threat-model.md`, `docs/ci-security.md`, and `docs/remediation.md`.
 - Dependency maintenance: <https://github.com/JSONbored/nightward/blob/main/docs/dependency-maintenance.md>
 - DCO: `CONTRIBUTING.md` and the CI DCO sign-off job.
-- Release readiness: `.goreleaser.yml`, `make release-snapshot`, signed checksum config, SBOM config, and release workflow.
+- Release readiness: `.goreleaser.yml`, `make release-snapshot`, signed checksum config, SBOM config, release workflow, and release-gated npm launcher package.
 
 ## Manual Badge Actions
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,56 @@
+# Release Process
+
+Nightward releases are human-gated. Do not create a tag until the release candidate PR is reviewed and CI is green.
+
+## Pre-Release Checklist
+
+1. Confirm `main` is clean and up to date.
+2. Run `make verify`.
+3. Run `make release-snapshot`.
+4. Confirm `renovate-config-validator renovate.json` passes.
+5. Confirm `npm audit --audit-level=moderate` passes in both `integrations/raycast` and `packages/npm`.
+6. Review `CHANGELOG.md` for user-facing changes, security notes, and breaking pre-1.0 behavior.
+7. Confirm the OpenSSF evidence doc is current.
+
+## Tagging
+
+Use strict SemVer tags:
+
+```sh
+git tag -s v0.1.0 -m "chore(release): 0.1.0"
+git push origin v0.1.0
+```
+
+Unsigned tags should not be used for public releases.
+
+## GitHub Release
+
+The release workflow runs GoReleaser from strict `vX.Y.Z` tags. It builds archives, creates checksums, generates SBOMs, signs `checksums.txt` with Cosign, and publishes the GitHub Release.
+
+Verify a release locally with:
+
+```sh
+cosign verify-blob \
+  --certificate-identity-regexp 'https://github.com/JSONbored/nightward/.github/workflows/release.yml@refs/tags/v.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --signature checksums.txt.sig \
+  checksums.txt
+```
+
+Then verify an archive:
+
+```sh
+sha256sum -c checksums.txt --ignore-missing
+```
+
+## NPM Publish
+
+The npm package is release-gated and disabled by default. To publish it:
+
+1. Configure npm trusted publishing or `NPM_TOKEN`.
+2. Set repository variable `NPM_PUBLISH=true`.
+3. Push a reviewed release tag.
+
+The npm job stamps `packages/npm/package.json` to the tag version, tests the launcher, audits dependencies, dry-runs package contents, and publishes with provenance.
+
+The npm package should remain a launcher for GitHub Release binaries. Do not add a `postinstall` downloader or a second implementation of Nightward.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,6 +19,7 @@ make trunk-flaky-validate
 make trunk-check
 make ci-scripts-test
 make raycast-verify
+make npm-package-verify
 make release-snapshot
 make verify
 ```
@@ -45,6 +46,7 @@ make verify
 - `make coverage-check` enforces at least 80% combined statement coverage for `./internal/...`.
 - `make ci-scripts-test` verifies repository-maintained CI helper scripts such as DCO checking.
 - Raycast dependency audits run with `npm audit --audit-level=moderate`.
+- The npm launcher tests run with `make npm-package-verify`, including unit tests, `npm audit`, and `npm pack --dry-run`.
 
 ## Trunk Flaky Tests
 
@@ -78,3 +80,17 @@ npm run build
 ```
 
 `npm run dev` is the manual smoke path when the Raycast CLI is available. Do not run `npm run publish` unless release/publish scope is explicit.
+
+## NPM Launcher
+
+The release-gated npm package lives under `packages/npm`.
+
+```sh
+cd packages/npm
+npm ci
+npm test
+npm audit --audit-level=moderate
+npm run pack:dry-run
+```
+
+The launcher must remain dependency-light, avoid `postinstall`, and verify downloaded GitHub Release archives against `checksums.txt` before extraction.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -13,10 +13,13 @@ make gosec
 make gitleaks
 make govulncheck
 make fuzz-smoke
+make coverage-check
 make test-junit
 make trunk-flaky-validate
 make trunk-check
+make ci-scripts-test
 make raycast-verify
+make release-snapshot
 make verify
 ```
 
@@ -39,6 +42,8 @@ make verify
 - TUI model tests cover tab switching, search, filters, help, cursor clamping, wide detail panes, compact terminal rendering, and redaction.
 - Raycast extension tests cover pure redaction/formatting helpers and safe command execution wrappers.
 - `go vet`, `staticcheck`, `gosec`, `gitleaks`, `govulncheck`, and fuzz smoke tests are part of the local verification bar. `#nosec` comments must include a narrow reason tied to an intentional local CLI behavior.
+- `make coverage-check` enforces at least 80% combined statement coverage for `./internal/...`.
+- `make ci-scripts-test` verifies repository-maintained CI helper scripts such as DCO checking.
 - Raycast dependency audits run with `npm audit --audit-level=moderate`.
 
 ## Trunk Flaky Tests
@@ -55,6 +60,10 @@ trunk flakytests validate --junit-paths reports/go-tests.xml,reports/junit/rayca
 ```
 
 CI validates that the JUnit report is parseable for every pull request. Trunk uploads are gated on `TRUNK_ORG_URL_SLUG` and `TRUNK_API_TOKEN`, so contributors do not need Trunk credentials.
+
+## Release Snapshot
+
+`make release-snapshot` installs the pinned Syft SBOM tool into the local Go bin directory, then runs GoReleaser in snapshot mode. It verifies archive, checksum, and SBOM configuration without publishing, signing, or creating a tag. Real release signing remains restricted to the tag-driven release workflow.
 
 ## Raycast Extension
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,39 @@
+# Threat Model
+
+Nightward inspects local AI agent and devtool state, so its primary risk is accidental disclosure or mutation of private local data.
+
+## Assets
+
+- MCP server configs and executable arguments.
+- Agent/editor settings, skills, rules, and local workflow files.
+- Credentials, auth files, tokens, headers, env files, and private local paths.
+- Redacted reports, SARIF files, fix-plan exports, and scheduled scan reports.
+- Release artifacts, GitHub Actions workflows, and package metadata.
+
+## Trust Boundaries
+
+- Local filesystem input is untrusted. Config files may be malformed, hostile, huge, symlinked, or privacy-sensitive.
+- CLI/TUI/Raycast output is a disclosure boundary. Secret values must not cross it.
+- Optional providers are execution boundaries. They are discovered but not installed or run online by default.
+- GitHub Actions and Trunk integrations treat repository contents and PR input as untrusted.
+- Scheduler install/remove is an explicit write boundary and must stay user-level.
+- Release automation is a privileged publishing boundary.
+
+## Threats And Controls
+
+- Secret disclosure: redact env/header values, secret-looking args, token-like strings, and Markdown/SARIF/TUI exports; test every output surface.
+- Unexpected mutation: scan, doctor, findings, fix, policy, backup-plan, snapshot, analysis, TUI, Raycast, and GitHub Action policy paths stay read-only except explicit output files.
+- Unsafe portability: classify secret-auth, app-owned, runtime-cache, machine-local, and unknown state conservatively.
+- MCP execution ambiguity: flag shell wrappers, broad filesystem access, unpinned package execution, local endpoints, sensitive headers/env, token paths, and unknown shapes.
+- Supply-chain compromise: pin GitHub Actions by full SHA, use Renovate, run Gitleaks/govulncheck/OSV/CodeQL/gosec/staticcheck/Trunk, and keep release artifacts signed.
+- Malformed config denial-of-service: keep parser/fuzz tests for MCP JSON/TOML/YAML and add size/symlink hardening as the scanner expands.
+
+## Non-Goals
+
+Nightward does not prove a tool, package, MCP server, or URL is safe. It reports local structure, known risky signals, and review guidance.
+
+Nightward does not back up, restore, sync, push to Git, or mutate agent configs in v1.
+
+## Review Triggers
+
+Update this model before adding live config mutation, restore, encrypted sync, online provider execution, hosted dashboards, release publishing changes, or new writable integrations.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -17,7 +17,7 @@ Nightward inspects local AI agent and devtool state, so its primary risk is acci
 - Optional providers are execution boundaries. They are discovered but not installed or run online by default.
 - GitHub Actions and Trunk integrations treat repository contents and PR input as untrusted.
 - Scheduler install/remove is an explicit write boundary and must stay user-level.
-- Release automation is a privileged publishing boundary.
+- Release automation and npm publishing are privileged publishing boundaries.
 
 ## Threats And Controls
 
@@ -25,7 +25,7 @@ Nightward inspects local AI agent and devtool state, so its primary risk is acci
 - Unexpected mutation: scan, doctor, findings, fix, policy, backup-plan, snapshot, analysis, TUI, Raycast, and GitHub Action policy paths stay read-only except explicit output files.
 - Unsafe portability: classify secret-auth, app-owned, runtime-cache, machine-local, and unknown state conservatively.
 - MCP execution ambiguity: flag shell wrappers, broad filesystem access, unpinned package execution, local endpoints, sensitive headers/env, token paths, and unknown shapes.
-- Supply-chain compromise: pin GitHub Actions by full SHA, use Renovate, run Gitleaks/govulncheck/OSV/CodeQL/gosec/staticcheck/Trunk, and keep release artifacts signed.
+- Supply-chain compromise: pin GitHub Actions by full SHA, use Renovate, run Gitleaks/govulncheck/OSV/CodeQL/gosec/staticcheck/Trunk, keep release artifacts signed, and keep the npm package as a no-postinstall launcher that verifies archive checksums.
 - Malformed config denial-of-service: keep parser/fuzz tests for MCP JSON/TOML/YAML and add size/symlink hardening as the scanner expands.
 
 ## Non-Goals
@@ -36,4 +36,4 @@ Nightward does not back up, restore, sync, push to Git, or mutate agent configs 
 
 ## Review Triggers
 
-Update this model before adding live config mutation, restore, encrypted sync, online provider execution, hosted dashboards, release publishing changes, or new writable integrations.
+Update this model before adding live config mutation, restore, encrypted sync, online provider execution, hosted dashboards, release/npm publishing changes, or new writable integrations.

--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -1,7 +1,7 @@
 package analysis
 
 import (
-	"crypto/sha1" // #nosec G505 -- used only for short deterministic non-security IDs.
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"os/exec"
@@ -422,7 +422,7 @@ func selectedProviders(with []string) map[string]bool {
 }
 
 func stableID(parts ...string) string {
-	hash := sha1.Sum([]byte(strings.Join(parts, "\x00"))) // #nosec G401 -- stable label only, not a cryptographic control.
+	hash := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
 	return hex.EncodeToString(hash[:])[:12]
 }
 

--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -90,3 +90,77 @@ func TestProviderDoctorFindsFakeLocalProvider(t *testing.T) {
 	}
 	t.Fatal("missing gitleaks provider")
 }
+
+func TestExplainRelativePathAndHumanProviderSummary(t *testing.T) {
+	report := Run(inventory.Report{
+		Findings: []inventory.Finding{
+			{
+				ID:             "mcp_shell_command-111111111111",
+				Tool:           "Codex",
+				Path:           "/tmp/work/config.toml",
+				Rule:           "mcp_shell_command",
+				Severity:       inventory.RiskMedium,
+				Message:        "Shell wrapper",
+				Recommendation: "Use a direct command.",
+			},
+		},
+	}, Options{})
+
+	if len(report.Signals) != 1 {
+		t.Fatalf("expected one signal: %#v", report.Signals)
+	}
+	fullID := report.Signals[0].ID
+	if signal, ok := Explain(report, fullID); !ok || signal.ID != fullID {
+		t.Fatalf("full signal explain failed: %#v ok=%t", signal, ok)
+	}
+	if signal, ok := Explain(report, fullID[:8]); !ok || signal.ID != fullID {
+		t.Fatalf("prefix signal explain failed: %#v ok=%t", signal, ok)
+	}
+	if _, ok := Explain(report, "missing"); ok {
+		t.Fatal("unexpected match for missing signal")
+	}
+	if got := RelativeWorkspacePath("/tmp/work", "/tmp/work/config.toml"); got != "config.toml" {
+		t.Fatalf("unexpected relative path: %s", got)
+	}
+	if got := RelativeWorkspacePath("/tmp/work", "/tmp/else/config.toml"); got != "/tmp/else/config.toml" {
+		t.Fatalf("unexpected path outside workspace: %s", got)
+	}
+
+	enabled := HumanProviderSummary(ProviderStatus{Provider: Provider{Name: "gitleaks"}, Enabled: true, Available: true, Status: "ready"})
+	disabled := HumanProviderSummary(ProviderStatus{Provider: Provider{Name: "socket"}, Enabled: false, Available: false, Status: "missing"})
+	if !strings.Contains(enabled, "enabled ready (available)") || !strings.Contains(disabled, "disabled missing") {
+		t.Fatalf("unexpected provider summaries: %q / %q", enabled, disabled)
+	}
+}
+
+func TestAnalysisItemCategoriesAndRiskRanks(t *testing.T) {
+	report := inventory.Report{Items: []inventory.Item{
+		{ID: "machine", Classification: inventory.MachineLocal, Path: "/tmp/socket", Risk: inventory.RiskMedium},
+		{ID: "app", Classification: inventory.AppOwned, Path: "/tmp/app.db", Risk: inventory.RiskLow},
+		{ID: "portable", Classification: inventory.Portable, Path: "/tmp/config", Risk: inventory.RiskInfo},
+	}}
+	out := Run(report, Options{})
+	if out.Summary.TotalSignals != 2 {
+		t.Fatalf("expected machine-local and app-owned signals only: %#v", out.Summary)
+	}
+	if out.Summary.SignalsByCategory[CategoryLocality] != 1 || out.Summary.SignalsByCategory[CategoryAppState] != 1 {
+		t.Fatalf("unexpected item categories: %#v", out.Summary.SignalsByCategory)
+	}
+
+	for rule, want := range map[string]SignalCategory{
+		"mcp_unpinned_package":  CategorySupplyChain,
+		"mcp_secret_header":     CategorySecrets,
+		"mcp_broad_filesystem":  CategoryFilesystem,
+		"mcp_local_endpoint":    CategoryNetwork,
+		"mcp_unknown_command":   CategoryExecution,
+		"mcp_server_review":     CategoryExecution,
+		"nightward/custom_rule": CategoryUnknown,
+	} {
+		if got := categoryForRule(rule); got != want {
+			t.Fatalf("categoryForRule(%q)=%q, want %q", rule, got, want)
+		}
+	}
+	if riskRank(inventory.RiskCritical) <= riskRank(inventory.RiskHigh) || riskRank(inventory.RiskInfo) != 1 {
+		t.Fatal("unexpected risk ranking")
+	}
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -7,6 +7,14 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/jsonbored/nightward/internal/analysis"
+	"github.com/jsonbored/nightward/internal/backupplan"
+	"github.com/jsonbored/nightward/internal/inventory"
+	"github.com/jsonbored/nightward/internal/policy"
+	"github.com/jsonbored/nightward/internal/schedule"
+	"github.com/jsonbored/nightward/internal/snapshot"
 )
 
 func TestReadOnlyCommandsDoNotMutateHome(t *testing.T) {
@@ -146,6 +154,34 @@ API_TOKEN = "`+secretValue+`"
 		if code == 0 {
 			t.Fatalf("%s unexpectedly succeeded", strings.Join(args, " "))
 		}
+	}
+}
+
+func TestHelpVersionAndCommandErrors(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"--help"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("help failed: %d %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Usage:") || !strings.Contains(stdout.String(), "Canonical command") {
+		t.Fatalf("unexpected help output:\n%s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := RunWithName("nw", []string{"version"}, &stdout, &stderr); code != 0 || strings.TrimSpace(stdout.String()) == "" {
+		t.Fatalf("version failed: code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := RunWithName("nw", []string{"providers", "bogus"}, &stdout, &stderr); code == 0 || !strings.Contains(stderr.String(), "usage: nightward providers") {
+		t.Fatalf("expected providers error, code=%d stderr=%q", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := RunWithName("nw", []string{"bogus"}, &stdout, &stderr); code == 0 || !strings.Contains(stderr.String(), "unknown command") {
+		t.Fatalf("expected unknown command error, code=%d stderr=%q", code, stderr.String())
 	}
 }
 
@@ -303,6 +339,79 @@ func TestPolicyCheckUsesConfig(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), `"ignored": 1`) {
 		t.Fatalf("expected ignored finding in output: %s", stdout.String())
+	}
+}
+
+func TestHumanPrintersCoverPolicySnapshotAndSchedule(t *testing.T) {
+	var out bytes.Buffer
+	printPolicy(&out, policy.Report{
+		Strict:    true,
+		Passed:    false,
+		Threshold: inventory.RiskMedium,
+		Summary:   policy.Summary{TotalFindings: 2, Violations: 1, Ignored: 1},
+		Violations: []inventory.Finding{
+			{ID: "mcp_secret_env-1", Severity: inventory.RiskCritical, Rule: "mcp_secret_env", Message: "Secret env"},
+		},
+	})
+	if text := out.String(); !strings.Contains(text, "policy failed") || !strings.Contains(text, "mcp_secret_env") {
+		t.Fatalf("unexpected policy printer output:\n%s", text)
+	}
+
+	out.Reset()
+	printSnapshotPlan(&out, snapshot.Plan{
+		TargetRoot: "/tmp/snapshots",
+		Summary:    snapshot.Summary{Total: 1, Include: 1},
+		Entries: []snapshot.Entry{
+			{Source: "/tmp/config.toml", Target: "/tmp/snapshots/config.toml", Tool: "Codex", Action: backupplan.ActionInclude},
+		},
+	})
+	if text := out.String(); !strings.Contains(text, "Snapshot dry-run plan") || !strings.Contains(text, "config.toml") {
+		t.Fatalf("unexpected snapshot plan output:\n%s", text)
+	}
+
+	out.Reset()
+	printSnapshotDiff(&out, snapshot.Diff{
+		Summary: snapshot.DiffSummary{Added: 1, Removed: 1, Changed: 1},
+		Added:   []snapshot.Entry{{Source: "/tmp/new", Tool: "Codex"}},
+		Removed: []snapshot.Entry{{Source: "/tmp/old", Tool: "Claude"}},
+		Changed: []snapshot.Change{{Source: "/tmp/config", Before: snapshot.Entry{Action: backupplan.ActionReview}, After: snapshot.Entry{Tool: "Cursor", Action: backupplan.ActionInclude}}},
+	})
+	if text := out.String(); !strings.Contains(text, "added") || !strings.Contains(text, "removed") || !strings.Contains(text, "changed") {
+		t.Fatalf("unexpected snapshot diff output:\n%s", text)
+	}
+
+	now := time.Date(2026, 4, 30, 2, 17, 0, 0, time.UTC)
+	out.Reset()
+	printSchedulePlan(&out, schedule.Plan{
+		Preset:     "nightly",
+		Platform:   "darwin",
+		Command:    []string{"nw", "scan"},
+		ReportDir:  "/tmp/reports",
+		LastReport: "/tmp/reports/latest.json",
+		LastRun:    &now,
+		Files:      []schedule.GeneratedFile{{Path: "/tmp/agent.plist", Content: "<plist/>", Mode: 0644}},
+		Notes:      []string{"dry run"},
+	})
+	if text := out.String(); !strings.Contains(text, "Schedule preset") || !strings.Contains(text, "agent.plist") || !strings.Contains(text, "dry run") {
+		t.Fatalf("unexpected schedule output:\n%s", text)
+	}
+}
+
+func TestHumanAnalysisSignalPrinter(t *testing.T) {
+	var out bytes.Buffer
+	printSignal(&out, analysis.Signal{
+		ID:             "signal-1",
+		Rule:           "nightward/mcp_secret_env",
+		Severity:       inventory.RiskCritical,
+		Confidence:     "high",
+		Provider:       "nightward",
+		Path:           "/tmp/config.toml",
+		Evidence:       "env_key=API_TOKEN",
+		Recommendation: "Externalize the secret.",
+		Why:            "Secrets should not live in portable config.",
+	})
+	if text := out.String(); !strings.Contains(text, "signal-1") || !strings.Contains(text, "Externalize") || !strings.Contains(text, "Why this matters") {
+		t.Fatalf("unexpected signal output:\n%s", text)
 	}
 }
 

--- a/internal/fixplan/plan_test.go
+++ b/internal/fixplan/plan_test.go
@@ -141,6 +141,90 @@ func TestBuildPreviewDoesNotGuessPackageVersions(t *testing.T) {
 	}
 }
 
+func TestBuildPreviewReplacesSimpleShellWrapperAndRedactsArgs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(`[mcp_servers.demo]
+command = "sh"
+args = ["-c", "node server.js --api-key super-secret-value"]
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	report := inventory.Report{Findings: []inventory.Finding{
+		{
+			ID:             "mcp_shell_command-111111111111",
+			Tool:           "Codex",
+			Path:           path,
+			Server:         "demo",
+			Rule:           "mcp_shell_command",
+			Severity:       inventory.RiskMedium,
+			FixKind:        inventory.FixReplaceShellWrapper,
+			RequiresReview: true,
+			PatchHint: &inventory.PatchHint{
+				Kind:          inventory.FixReplaceShellWrapper,
+				DirectCommand: "node",
+				DirectArgs:    []string{"server.js", "--api-key", "super-secret-value"},
+			},
+		},
+	}}
+
+	preview := BuildPreview(report, Selector{All: true})
+	if preview.Summary.Patchable != 1 {
+		t.Fatalf("expected shell wrapper patch: %#v", preview)
+	}
+	markdown := PreviewMarkdown(preview)
+	if !strings.Contains(markdown, `command = "node"`) || !strings.Contains(markdown, "[redacted]") {
+		t.Fatalf("unexpected shell preview markdown:\n%s", markdown)
+	}
+	if strings.Contains(markdown, "super-secret-value") {
+		t.Fatalf("shell wrapper preview leaked secret:\n%s", markdown)
+	}
+}
+
+func TestBuildPreviewExplainsUnpatchableSecretShapes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "missing.json")
+	if err := os.WriteFile(path, []byte(`{"mcpServers":{"demo":{"env":{"API_TOKEN":"[redacted]"}}}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	report := inventory.Report{Findings: []inventory.Finding{
+		{
+			ID:        "missing-server",
+			Rule:      "mcp_secret_env",
+			PatchHint: &inventory.PatchHint{Kind: inventory.FixExternalizeSecret, EnvKey: "API_TOKEN", InlineSecret: true},
+		},
+		{
+			ID:        "missing-env-key",
+			Server:    "demo",
+			Rule:      "mcp_secret_env",
+			Path:      path,
+			PatchHint: &inventory.PatchHint{Kind: inventory.FixExternalizeSecret, InlineSecret: true},
+		},
+	}}
+
+	preview := BuildPreview(report, Selector{All: true})
+	if preview.Summary.Blocked != 2 || preview.Summary.Patchable != 0 {
+		t.Fatalf("expected blocked previews: %#v", preview.Summary)
+	}
+	combined := PreviewMarkdown(preview)
+	for _, want := range []string{"server name is unknown", "env key is unknown"} {
+		if !strings.Contains(combined, want) {
+			t.Fatalf("preview missing reason %q:\n%s", want, combined)
+		}
+	}
+}
+
+func TestPreviewMarkdownAndDiffEmptySelection(t *testing.T) {
+	preview := BuildPreview(inventory.Report{}, Selector{All: true})
+	if got := PreviewDiff(preview); !strings.Contains(got, "No redacted patch previews") {
+		t.Fatalf("unexpected empty diff: %s", got)
+	}
+	if got := PreviewMarkdown(preview); !strings.Contains(got, "No findings matched") {
+		t.Fatalf("unexpected empty markdown: %s", got)
+	}
+}
+
 func TestSelectorFiltersFindings(t *testing.T) {
 	report := inventory.Report{Findings: []inventory.Finding{
 		{ID: "mcp_shell_command-aaaaaaaaaaaa", Rule: "mcp_shell_command", FixAvailable: true},

--- a/internal/inventory/scanner.go
+++ b/internal/inventory/scanner.go
@@ -1,7 +1,7 @@
 package inventory
 
 import (
-	"crypto/sha1" // #nosec G505 -- used only for short deterministic non-security IDs.
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"os"
@@ -260,7 +260,7 @@ func inspectPath(path string, spec pathSpec) (Item, bool) {
 }
 
 func stableID(parts ...string) string {
-	hash := sha1.Sum([]byte(strings.Join(parts, "\x00"))) // #nosec G401 -- stable label only, not a cryptographic control.
+	hash := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
 	return hex.EncodeToString(hash[:])[:12]
 }
 

--- a/internal/inventory/testdata/golden/url-findings.golden.json
+++ b/internal/inventory/testdata/golden/url-findings.golden.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "mcp_secret_header-bcdb8f0837fd",
+    "id": "mcp_secret_header-caa3df1f711e",
     "tool": "Codex",
     "path": "/tmp/nightward-golden-home/.codex/config.toml",
     "server": "header",
@@ -29,7 +29,7 @@
     }
   },
   {
-    "id": "mcp_secret_header-eba7e3966510",
+    "id": "mcp_secret_header-5212d7dbf262",
     "tool": "Codex",
     "path": "/tmp/nightward-golden-home/.codex/config.toml",
     "server": "header",
@@ -57,7 +57,7 @@
     }
   },
   {
-    "id": "mcp_local_endpoint-cf933c07a3ec",
+    "id": "mcp_local_endpoint-a1016cb2257c",
     "tool": "Codex",
     "path": "/tmp/nightward-golden-home/.codex/config.toml",
     "server": "local",
@@ -81,7 +81,7 @@
     ]
   },
   {
-    "id": "mcp_unknown_command-a5e74f7a7e1d",
+    "id": "mcp_unknown_command-a318c5ca6d87",
     "tool": "Codex",
     "path": "/tmp/nightward-golden-home/.codex/config.toml",
     "server": "unknown",
@@ -105,7 +105,7 @@
     ]
   },
   {
-    "id": "mcp_server_review-d934e91f9921",
+    "id": "mcp_server_review-895197e30eb1",
     "tool": "Codex",
     "path": "/tmp/nightward-golden-home/.codex/config.toml",
     "server": "header",
@@ -129,7 +129,7 @@
     ]
   },
   {
-    "id": "mcp_server_review-cf933c07a3ec",
+    "id": "mcp_server_review-a1016cb2257c",
     "tool": "Codex",
     "path": "/tmp/nightward-golden-home/.codex/config.toml",
     "server": "local",
@@ -153,7 +153,7 @@
     ]
   },
   {
-    "id": "mcp_server_review-f17f9e7bd3e7",
+    "id": "mcp_server_review-ebc91cff4b17",
     "tool": "Codex",
     "path": "/tmp/nightward-golden-home/.codex/config.toml",
     "server": "remote",
@@ -177,7 +177,7 @@
     ]
   },
   {
-    "id": "mcp_server_review-a5e74f7a7e1d",
+    "id": "mcp_server_review-a318c5ca6d87",
     "tool": "Codex",
     "path": "/tmp/nightward-golden-home/.codex/config.toml",
     "server": "unknown",

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -52,6 +52,46 @@ func TestLoadConfigRejectsUnknownKeysAndReasonlessIgnores(t *testing.T) {
 	}
 }
 
+func TestDefaultConfigExplainValidateAndWriteSARIF(t *testing.T) {
+	config := DefaultConfig()
+	if config.SeverityThreshold != inventory.RiskHigh || config.SARIF.ToolName != "Nightward" {
+		t.Fatalf("unexpected default config: %#v", config)
+	}
+	yamlText := DefaultConfigYAML()
+	for _, want := range []string{"severity_threshold: high", "analysis_threshold: high", "tool_name: Nightward"} {
+		if !strings.Contains(yamlText, want) {
+			t.Fatalf("default config YAML missing %q:\n%s", want, yamlText)
+		}
+	}
+	if text := Explain(); !strings.Contains(text, "KnownFields") && !strings.Contains(text, "Ignore entries must include a reason") {
+		t.Fatalf("unexpected policy explanation:\n%s", text)
+	}
+	if err := ValidateConfig(Config{SeverityThreshold: "urgent"}); err == nil {
+		t.Fatal("expected unsupported severity threshold error")
+	}
+	if err := ValidateConfig(Config{AnalysisThreshold: "urgent"}); err == nil {
+		t.Fatal("expected unsupported analysis threshold error")
+	}
+	if err := ValidateConfig(Config{IgnoreFindings: []IgnoreFinding{{Reason: "missing id"}}}); err == nil {
+		t.Fatal("expected missing ignore finding id error")
+	}
+	if err := ValidateConfig(Config{IgnoreRules: []IgnoreRule{{Reason: "missing rule"}}}); err == nil {
+		t.Fatal("expected missing ignore rule error")
+	}
+
+	out := filepath.Join(t.TempDir(), "nested", "nightward.sarif")
+	if err := WriteSARIFObject(BuildSARIF(inventory.Report{}), out); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"2.1.0"`) {
+		t.Fatalf("unexpected SARIF file:\n%s", data)
+	}
+}
+
 func TestCheckWithConfigIgnoresWithReasonAndOverridesThreshold(t *testing.T) {
 	report := inventory.Report{
 		GeneratedAt: time.Date(2026, 4, 30, 7, 0, 0, 0, time.UTC),

--- a/internal/schedule/schedule_test.go
+++ b/internal/schedule/schedule_test.go
@@ -1,8 +1,11 @@
 package schedule
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestBuildPlanForDarwin(t *testing.T) {
@@ -44,5 +47,57 @@ func TestBuildPlanForUnsupportedOSReturnsCronTextOnly(t *testing.T) {
 	}
 	if len(plan.Notes) == 0 {
 		t.Fatal("expected cron mutation warning note")
+	}
+}
+
+func TestBuildPlanRejectsUnsupportedPreset(t *testing.T) {
+	if _, err := BuildPlanForOS("linux", "/home/test", "nightward", "hourly"); err == nil {
+		t.Fatal("expected unsupported preset error")
+	}
+}
+
+func TestStatusReadsLatestReportAndFindingCount(t *testing.T) {
+	home := t.TempDir()
+	reportDir := filepath.Join(home, ".local", "state", "nightward", "reports")
+	if err := os.MkdirAll(reportDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	oldReport := filepath.Join(reportDir, "old.json")
+	newReport := filepath.Join(reportDir, "new.json")
+	if err := os.WriteFile(oldReport, []byte(`{"findings":[{"severity":"low"}]}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(newReport, []byte(`{"findings":[{"severity":"medium"},{"severity":"high"}]}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Date(2026, 4, 30, 1, 0, 0, 0, time.UTC)
+	newTime := time.Date(2026, 4, 30, 2, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(oldReport, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(newReport, newTime, newTime); err != nil {
+		t.Fatal(err)
+	}
+
+	status := Status(home)
+	if status.LastReport != newReport || status.LastRun == nil || !status.LastRun.Equal(newTime) {
+		t.Fatalf("unexpected latest report status: %#v", status)
+	}
+	if status.LastFindings != 2 {
+		t.Fatalf("expected two findings, got %d", status.LastFindings)
+	}
+}
+
+func TestEscapingHelpers(t *testing.T) {
+	joined := shellJoin([]string{"nightward", "scan", "--path", "/tmp/has space/it's"})
+	if !strings.Contains(joined, `'/tmp/has space/it'\''s'`) {
+		t.Fatalf("unexpected shell join: %s", joined)
+	}
+	escaped, err := xmlEscape(`a&b"c`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if escaped != `a&amp;b&#34;c` {
+		t.Fatalf("unexpected xml escape: %s", escaped)
 	}
 }

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -1,6 +1,9 @@
 package snapshot
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -36,5 +39,34 @@ func TestCompareReportsAddedRemovedAndChangedEntries(t *testing.T) {
 	diff := Compare("before.json", "after.json", before, after)
 	if diff.Summary.Added != 1 || diff.Summary.Removed != 1 || diff.Summary.Changed != 1 {
 		t.Fatalf("unexpected diff: %#v", diff.Summary)
+	}
+}
+
+func TestLoadSnapshotPlan(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "snapshot.json")
+	original := Plan{
+		GeneratedAt: time.Date(2026, 4, 30, 7, 0, 0, 0, time.UTC),
+		TargetRoot:  "/backup",
+		Entries: []Entry{
+			{Source: "/home/me/.codex/config.toml", Target: "/backup/config/codex/config.toml", Tool: "Codex", Classification: inventory.Portable, Action: backupplan.ActionInclude},
+		},
+		Summary: Summary{Total: 1, Include: 1},
+	}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.TargetRoot != original.TargetRoot || len(loaded.Entries) != 1 || loaded.Entries[0].Source != original.Entries[0].Source {
+		t.Fatalf("unexpected loaded snapshot: %#v", loaded)
+	}
+	if _, err := Load(filepath.Join(t.TempDir(), "missing.json")); err == nil {
+		t.Fatal("expected missing snapshot load error")
 	}
 }

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -306,3 +306,80 @@ func TestClipboardAndOpenCommandBuilders(t *testing.T) {
 		t.Fatalf("unexpected open command: path=%s args=%v", openCmd.Path, openCmd.Args)
 	}
 }
+
+func TestTUISelectionsForSignalFixAndBackup(t *testing.T) {
+	report := inventory.Report{
+		Home: "/tmp/nightward-home",
+		Findings: []inventory.Finding{
+			{
+				ID:             "mcp_shell_command-111111111111",
+				Rule:           "mcp_shell_command",
+				Severity:       inventory.RiskMedium,
+				FixAvailable:   true,
+				FixKind:        inventory.FixReplaceShellWrapper,
+				FixSummary:     "Replace shell wrapper.",
+				FixSteps:       []string{"Use node directly."},
+				Recommendation: "Use a direct command.",
+			},
+		},
+		Items: []inventory.Item{
+			{ID: "item-1", Tool: "Codex", Path: "/tmp/config.toml", Classification: inventory.Portable, Risk: inventory.RiskLow},
+		},
+	}
+	m := model{
+		report: report,
+		width:  120,
+		height: 40,
+	}
+
+	m.tab = 3
+	if got, ok := m.currentSignal(); !ok || got.Rule != "nightward/mcp_shell_command" {
+		t.Fatalf("unexpected current signal: %#v ok=%t", got, ok)
+	}
+	if text, label, ok := m.copySelection(); !ok || label != "analysis recommendation" || !strings.Contains(text, "Use a direct command") {
+		t.Fatalf("unexpected signal copy: %q %q %t", text, label, ok)
+	}
+
+	m.tab = 4
+	if got, ok := m.currentFix(); !ok || got.FindingID != "mcp_shell_command-111111111111" {
+		t.Fatalf("unexpected current fix: %#v ok=%t", got, ok)
+	}
+	if text, label, ok := m.copySelection(); !ok || label != "fix step" || !strings.Contains(text, "Use node directly") {
+		t.Fatalf("unexpected fix copy: %q %q %t", text, label, ok)
+	}
+
+	m.tab = 5
+	if got, ok := m.currentBackupEntry(); !ok || got.Source != "/tmp/config.toml" {
+		t.Fatalf("unexpected backup entry: %#v ok=%t", got, ok)
+	}
+	if text, label, ok := m.copySelection(); !ok || label != "backup source path" || text != "/tmp/config.toml" {
+		t.Fatalf("unexpected backup copy: %q %q %t", text, label, ok)
+	}
+}
+
+func TestTUIFiltersAndCursorHelpers(t *testing.T) {
+	report := inventory.Report{Findings: []inventory.Finding{
+		{ID: "a", Tool: "Codex", Rule: "mcp_secret_env", Severity: inventory.RiskCritical},
+		{ID: "b", Tool: "Cursor", Rule: "mcp_server_review", Severity: inventory.RiskInfo},
+	}}
+	m := model{report: report, tool: "Codex", rule: "mcp_secret_env", cursor: 10}
+	if tools := toolOptions(report.Findings); len(tools) != 2 || tools[0] != "Codex" {
+		t.Fatalf("unexpected tool options: %#v", tools)
+	}
+	if rules := ruleOptions(report.Findings); len(rules) != 2 || rules[0] != "mcp_secret_env" {
+		t.Fatalf("unexpected rule options: %#v", rules)
+	}
+	if got := cycle("", []string{"Codex", "Cursor"}); got != "Codex" {
+		t.Fatalf("unexpected cycle result: %q", got)
+	}
+	if got := severityColor(inventory.RiskLow); got == "" {
+		t.Fatal("expected low severity color")
+	}
+	filtered := m.filteredFindings()
+	if len(filtered) != 1 || filtered[0].ID != "a" {
+		t.Fatalf("unexpected filtered findings: %#v", filtered)
+	}
+	if got := clampCursor(10, 1, 5); got != 0 {
+		t.Fatalf("expected cursor clamp to zero, got %d", got)
+	}
+}

--- a/packages/npm/LICENSE
+++ b/packages/npm/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 JSONbored
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -1,0 +1,15 @@
+# nightward
+
+NPM launcher for Nightward.
+
+Nightward is a local-first TUI/CLI for auditing AI agent state, MCP config, and dotfiles backup safety.
+
+```sh
+npx nightward --help
+npm install -g nightward
+nw scan --json
+```
+
+This package is intentionally a thin launcher for the Go release binaries from <https://github.com/JSONbored/nightward>. It does not use a `postinstall` script. On first run, it downloads the matching GitHub Release archive, verifies the archive SHA-256 against `checksums.txt`, caches the extracted binaries, and then executes `nightward` or `nw`.
+
+For the strongest release verification, use the GitHub Release artifacts and verify the signed checksum file with Cosign.

--- a/packages/npm/bin/nightward.mjs
+++ b/packages/npm/bin/nightward.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { createWriteStream, existsSync } from "node:fs";
+import { chmod, mkdir, readFile, rm } from "node:fs/promises";
+import { get } from "node:https";
+import { homedir, platform as osPlatform, tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { spawn, spawnSync } from "node:child_process";
+
+const modulePath = fileURLToPath(import.meta.url);
+const packageRoot = path.resolve(path.dirname(modulePath), "..");
+const packageJSON = JSON.parse(await readFile(path.join(packageRoot, "package.json"), "utf8"));
+
+export function targetFor(platform = osPlatform(), arch = process.arch) {
+  const os = {
+    darwin: "darwin",
+    linux: "linux",
+    win32: "windows"
+  }[platform];
+  const cpu = {
+    arm64: "arm64",
+    x64: "amd64"
+  }[arch];
+  if (!os || !cpu) {
+    throw new Error(`unsupported platform: ${platform}/${arch}`);
+  }
+  return { os, arch: cpu, extension: os === "windows" ? ".zip" : ".tar.gz" };
+}
+
+export function assetName(version, target = targetFor()) {
+  return `nightward_${version}_${target.os}_${target.arch}${target.extension}`;
+}
+
+export function parseChecksums(text) {
+  const checksums = new Map();
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const [hash, file] = trimmed.split(/\s+/, 2);
+    if (/^[a-f0-9]{64}$/i.test(hash) && file) {
+      checksums.set(path.basename(file), hash.toLowerCase());
+    }
+  }
+  return checksums;
+}
+
+export async function sha256(file) {
+  const bytes = await readFile(file);
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+export async function verifyArchiveChecksum(file, expected) {
+  const actual = await sha256(file);
+  if (actual !== expected.toLowerCase()) {
+    throw new Error(`checksum mismatch for ${path.basename(file)}: expected ${expected}, got ${actual}`);
+  }
+}
+
+export function cacheRoot() {
+  if (process.env.NIGHTWARD_NPM_CACHE) {
+    return process.env.NIGHTWARD_NPM_CACHE;
+  }
+  return path.join(homedir(), ".cache", "nightward", "npm");
+}
+
+export function releaseVersion() {
+  return process.env.NIGHTWARD_NPM_VERSION || packageJSON.version;
+}
+
+export function releaseBaseURL(version = releaseVersion()) {
+  if (process.env.NIGHTWARD_NPM_DOWNLOAD_BASE) {
+    return process.env.NIGHTWARD_NPM_DOWNLOAD_BASE.replace(/\/$/, "");
+  }
+  return `https://github.com/JSONbored/nightward/releases/download/v${version}`;
+}
+
+export function commandName(argv1 = process.argv[1]) {
+  const invoked = path.basename(argv1 || "nightward").toLowerCase();
+  return invoked.startsWith("nw") ? "nw" : "nightward";
+}
+
+export function cachedBinaryPath(command = commandName(), version = releaseVersion(), target = targetFor()) {
+  const binary = target.os === "windows" ? `${command}.exe` : command;
+  return path.join(cacheRoot(), version, `${target.os}-${target.arch}`, binary);
+}
+
+async function download(url, destination, redirects = 0) {
+  if (redirects > 5) {
+    throw new Error(`too many redirects while downloading ${url}`);
+  }
+  await mkdir(path.dirname(destination), { recursive: true });
+  await new Promise((resolve, reject) => {
+    const request = get(url, (response) => {
+      if ([301, 302, 303, 307, 308].includes(response.statusCode || 0) && response.headers.location) {
+        response.resume();
+        download(new URL(response.headers.location, url).toString(), destination, redirects + 1).then(resolve, reject);
+        return;
+      }
+      if (response.statusCode !== 200) {
+        response.resume();
+        reject(new Error(`download failed for ${url}: HTTP ${response.statusCode}`));
+        return;
+      }
+      const file = createWriteStream(destination, { mode: 0o600 });
+      response.pipe(file);
+      file.on("finish", () => file.close(resolve));
+      file.on("error", reject);
+    });
+    request.on("error", reject);
+  });
+}
+
+async function downloadText(url) {
+  const file = path.join(tmpdir(), `nightward-checksums-${process.pid}-${Date.now()}.txt`);
+  try {
+    await download(url, file);
+    return await readFile(file, "utf8");
+  } finally {
+    await rm(file, { force: true });
+  }
+}
+
+async function extractArchive(archive, destination, target = targetFor()) {
+  await mkdir(destination, { recursive: true });
+  const result = target.os === "windows"
+    ? spawnSync("powershell", [
+      "-NoProfile",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-Command",
+      "Expand-Archive",
+      "-LiteralPath",
+      archive,
+      "-DestinationPath",
+      destination,
+      "-Force"
+    ], { stdio: "inherit" })
+    : spawnSync("tar", ["-xzf", archive, "-C", destination], { stdio: "inherit" });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`failed to extract ${path.basename(archive)}`);
+  }
+}
+
+export async function ensureBinary(command = commandName()) {
+  if (process.env.NIGHTWARD_BIN) {
+    return process.env.NIGHTWARD_BIN;
+  }
+
+  const version = releaseVersion();
+  if (version.includes("development")) {
+    throw new Error("the development npm package cannot download a release binary; set NIGHTWARD_BIN for local testing");
+  }
+
+  const target = targetFor();
+  const binary = cachedBinaryPath(command, version, target);
+  if (existsSync(binary)) {
+    return binary;
+  }
+
+  const asset = assetName(version, target);
+  const baseURL = releaseBaseURL(version);
+  const archive = path.join(cacheRoot(), version, `${target.os}-${target.arch}`, asset);
+  const installDir = path.dirname(binary);
+  const checksums = parseChecksums(await downloadText(`${baseURL}/checksums.txt`));
+  const expected = checksums.get(asset);
+  if (!expected) {
+    throw new Error(`checksums.txt does not include ${asset}`);
+  }
+
+  await download(`${baseURL}/${asset}`, archive);
+  await verifyArchiveChecksum(archive, expected);
+  await extractArchive(archive, installDir, target);
+  await chmod(binary, 0o755);
+  return binary;
+}
+
+async function main() {
+  const command = commandName();
+  const binary = await ensureBinary(command);
+  const child = spawn(binary, process.argv.slice(2), { stdio: "inherit" });
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exit(code ?? 1);
+  });
+  child.on("error", (error) => {
+    console.error(`nightward launcher failed: ${error.message}`);
+    process.exit(1);
+  });
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
+  main().catch((error) => {
+    console.error(`nightward launcher failed: ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/packages/npm/package-lock.json
+++ b/packages/npm/package-lock.json
@@ -1,0 +1,20 @@
+{
+  "name": "nightward",
+  "version": "0.0.0-development",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nightward",
+      "version": "0.0.0-development",
+      "license": "MIT",
+      "bin": {
+        "nightward": "bin/nightward.mjs",
+        "nw": "bin/nightward.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "nightward",
+  "version": "0.0.0-development",
+  "description": "Local-first TUI/CLI for auditing AI agent state, MCP config, and dotfiles backup safety.",
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "nightward": "bin/nightward.mjs",
+    "nw": "bin/nightward.mjs"
+  },
+  "files": [
+    "bin/",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "test": "node --test test/*.test.mjs",
+    "pack:dry-run": "npm pack --dry-run"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JSONbored/nightward.git",
+    "directory": "packages/npm"
+  },
+  "bugs": {
+    "url": "https://github.com/JSONbored/nightward/issues"
+  },
+  "homepage": "https://github.com/JSONbored/nightward#readme",
+  "keywords": [
+    "ai",
+    "agent",
+    "cli",
+    "codex",
+    "cursor",
+    "mcp",
+    "nightward",
+    "raycast",
+    "security",
+    "tui"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/packages/npm/test/launcher.test.mjs
+++ b/packages/npm/test/launcher.test.mjs
@@ -1,0 +1,60 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  assetName,
+  cachedBinaryPath,
+  commandName,
+  parseChecksums,
+  releaseBaseURL,
+  targetFor,
+  verifyArchiveChecksum
+} from "../bin/nightward.mjs";
+
+test("maps supported platforms to GoReleaser asset names", () => {
+  assert.equal(assetName("0.1.0", targetFor("darwin", "arm64")), "nightward_0.1.0_darwin_arm64.tar.gz");
+  assert.equal(assetName("0.1.0", targetFor("linux", "x64")), "nightward_0.1.0_linux_amd64.tar.gz");
+  assert.equal(assetName("0.1.0", targetFor("win32", "x64")), "nightward_0.1.0_windows_amd64.zip");
+});
+
+test("rejects unsupported npm launcher platforms", () => {
+  assert.throws(() => targetFor("freebsd", "x64"), /unsupported platform/);
+  assert.throws(() => targetFor("linux", "ia32"), /unsupported platform/);
+});
+
+test("parses checksums by archive basename", () => {
+  const checksums = parseChecksums(`
+9d5e3f5a13b86f661d9c61ef081bb9680186c02356b54e56058aca2c6f5393b6  nightward_0.1.0_linux_amd64.tar.gz
+invalid ignored
+  `);
+  assert.equal(checksums.get("nightward_0.1.0_linux_amd64.tar.gz"), "9d5e3f5a13b86f661d9c61ef081bb9680186c02356b54e56058aca2c6f5393b6");
+});
+
+test("verifies archive sha256 before extraction", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "nightward-npm-"));
+  const archive = path.join(dir, "archive.tar.gz");
+  await writeFile(archive, "nightward");
+  await verifyArchiveChecksum(archive, "3fc82c839197a667cf521e474cfdecb275ecc536fa0c66b2d9a3fbc98bc29a21");
+  await assert.rejects(
+    () => verifyArchiveChecksum(archive, "0".repeat(64)),
+    /checksum mismatch/
+  );
+});
+
+test("uses invocation name and environment overrides", () => {
+  assert.equal(commandName("/usr/local/bin/nw"), "nw");
+  assert.equal(commandName("/usr/local/bin/nightward"), "nightward");
+
+  process.env.NIGHTWARD_NPM_CACHE = "/tmp/nightward-cache";
+  process.env.NIGHTWARD_NPM_DOWNLOAD_BASE = "https://example.test/releases/";
+  try {
+    assert.equal(cachedBinaryPath("nw", "0.1.0", targetFor("linux", "x64")), "/tmp/nightward-cache/0.1.0/linux-amd64/nw");
+    assert.equal(releaseBaseURL("0.1.0"), "https://example.test/releases");
+  } finally {
+    delete process.env.NIGHTWARD_NPM_CACHE;
+    delete process.env.NIGHTWARD_NPM_DOWNLOAD_BASE;
+  }
+});

--- a/renovate.json
+++ b/renovate.json
@@ -52,7 +52,15 @@
       "labels": ["dependencies", "go", "security"]
     },
     {
-      "matchPackageNames": ["goreleaser/goreleaser"],
+      "matchPackageNames": [
+        "github.com/securego/gosec/v2",
+        "honnef.co/go/tools"
+      ],
+      "groupName": "go static analysis tooling",
+      "labels": ["dependencies", "go", "security"]
+    },
+    {
+      "matchPackageNames": ["goreleaser/goreleaser", "github.com/anchore/syft"],
       "groupName": "release tooling",
       "labels": ["dependencies", "release"]
     },
@@ -91,6 +99,46 @@
         "GOVULNCHECK_VERSION\\s*\\?=\\s*(?<currentValue>v?\\d+\\.\\d+\\.\\d+)"
       ],
       "depNameTemplate": "golang.org/x/vuln",
+      "datasourceTemplate": "go"
+    },
+    {
+      "customType": "regex",
+      "description": "Update gosec used by Makefile static analysis.",
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": [
+        "GOSEC_VERSION\\s*\\?=\\s*(?<currentValue>v?\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "github.com/securego/gosec/v2",
+      "datasourceTemplate": "go"
+    },
+    {
+      "customType": "regex",
+      "description": "Update staticcheck used by Makefile static analysis.",
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": [
+        "STATICCHECK_VERSION\\s*\\?=\\s*(?<currentValue>v?\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "honnef.co/go/tools",
+      "datasourceTemplate": "go"
+    },
+    {
+      "customType": "regex",
+      "description": "Update GoReleaser used by Makefile release snapshots.",
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": [
+        "GORELEASER_VERSION\\s*\\?=\\s*(?<currentValue>v?\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "goreleaser/goreleaser",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "description": "Update Syft used by Makefile release SBOM snapshots.",
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": [
+        "SYFT_VERSION\\s*\\?=\\s*(?<currentValue>v?\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "github.com/anchore/syft",
       "datasourceTemplate": "go"
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -34,9 +34,12 @@
     },
     {
       "matchManagers": ["npm"],
-      "matchFileNames": ["integrations/raycast/package.json"],
-      "groupName": "raycast extension npm packages",
-      "labels": ["dependencies", "raycast", "npm"]
+      "matchFileNames": [
+        "integrations/raycast/package.json",
+        "packages/npm/package.json"
+      ],
+      "groupName": "npm packages",
+      "labels": ["dependencies", "npm"]
     },
     {
       "matchPackageNames": ["gotest.tools/gotestsum"],

--- a/scripts/check-dco.sh
+++ b/scripts/check-dco.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base="${1:-${BASE_SHA:-origin/main}}"
+head="${2:-${HEAD_SHA:-HEAD}}"
+
+commits="$(git rev-list --no-merges "${base}..${head}")"
+missing=()
+while IFS= read -r commit; do
+  [[ -n "${commit}" ]] || continue
+  if ! git log -1 --format=%B "${commit}" | grep -Eiq '^Signed-off-by: .+ <.+@.+>$'; then
+    missing+=("${commit}")
+  fi
+done <<<"${commits}"
+
+if (( ${#missing[@]} > 0 )); then
+  echo "DCO sign-off missing from commits:" >&2
+  printf '  %s\n' "${missing[@]}" >&2
+  echo "Amend each commit with: git commit --amend -s --no-edit" >&2
+  exit 1
+fi
+
+echo "DCO sign-off check passed."

--- a/scripts/install-trunk-ci.sh
+++ b/scripts/install-trunk-ci.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${TRUNK_VERSION:-1.25.0}"
+install_dir="${TRUNK_INSTALL_DIR:-/usr/local/bin}"
+platform="${TRUNK_PLATFORM:-linux}"
+arch="${TRUNK_ARCH:-x86_64}"
+
+if [[ "${platform}" != "linux" || "${arch}" != "x86_64" ]]; then
+  echo "unsupported Trunk CI platform: ${platform}-${arch}" >&2
+  exit 2
+fi
+
+expected_sha256="${TRUNK_LINUX_X86_64_SHA256:-3845ff76a70cebb10e61a267ff719ffdccfa3ef6d877d51870a2c62b79603ab9}"
+url="https://trunk.io/releases/${version}/trunk-${version}-${platform}-${arch}.tar.gz"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+curl -fsSLo "${tmp_dir}/trunk.tar.gz" "${url}"
+if command -v sha256sum >/dev/null 2>&1; then
+  actual_sha256="$(sha256sum "${tmp_dir}/trunk.tar.gz" | awk '{print $1}')"
+else
+  actual_sha256="$(shasum -a 256 "${tmp_dir}/trunk.tar.gz" | awk '{print $1}')"
+fi
+if [[ "${actual_sha256}" != "${expected_sha256}" ]]; then
+  echo "Trunk checksum mismatch for ${url}" >&2
+  echo "expected: ${expected_sha256}" >&2
+  echo "actual:   ${actual_sha256}" >&2
+  exit 1
+fi
+
+tar -xzf "${tmp_dir}/trunk.tar.gz" -C "${tmp_dir}"
+install -m 0755 "${tmp_dir}/trunk" "${install_dir}/trunk"

--- a/scripts/test-action-paths.sh
+++ b/scripts/test-action-paths.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+validator="${repo_root}/scripts/validate-action-path.sh"
+
+"${validator}" output "nightward.sarif"
+"${validator}" output "reports/nightward.sarif"
+"${validator}" output "-"
+"${validator}" config ".nightward.yml"
+
+for value in "/tmp/nightward.sarif" "../nightward.sarif" "reports/../nightward.sarif" $'bad\npath' 'bad\path'; do
+  if "${validator}" output "${value}" >/dev/null 2>&1; then
+    echo "expected unsafe action path to fail: ${value}" >&2
+    exit 1
+  fi
+done
+
+echo "action path fixture tests passed."

--- a/scripts/test-dco.sh
+++ b/scripts/test-dco.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+git -C "${tmp_dir}" init -q
+git -C "${tmp_dir}" config user.name "Nightward Test"
+git -C "${tmp_dir}" config user.email "nightward@example.test"
+git -C "${tmp_dir}" config commit.gpgsign false
+
+printf 'base\n' >"${tmp_dir}/file.txt"
+git -C "${tmp_dir}" add file.txt
+git -C "${tmp_dir}" commit -q -m "test: base"
+base="$(git -C "${tmp_dir}" rev-parse HEAD)"
+
+printf 'signed\n' >>"${tmp_dir}/file.txt"
+git -C "${tmp_dir}" add file.txt
+git -C "${tmp_dir}" commit -q -s -m "test: signed change"
+(cd "${tmp_dir}" && "${repo_root}/scripts/check-dco.sh" "${base}" HEAD >/dev/null)
+
+printf 'unsigned\n' >>"${tmp_dir}/file.txt"
+git -C "${tmp_dir}" add file.txt
+git -C "${tmp_dir}" commit -q -m "test: unsigned change"
+if (cd "${tmp_dir}" && "${repo_root}/scripts/check-dco.sh" "${base}" HEAD >/dev/null 2>&1); then
+  echo "DCO test expected unsigned commit to fail" >&2
+  exit 1
+fi
+
+echo "DCO fixture tests passed."

--- a/scripts/validate-action-path.sh
+++ b/scripts/validate-action-path.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+name="${1:?path name required}"
+value="${2:-}"
+
+if [[ -z "${value}" ]]; then
+  exit 0
+fi
+if [[ "${name}" == "output" && "${value}" == "-" ]]; then
+  exit 0
+fi
+
+case "${value}" in
+  /* | *\\* | *$'\n'* | *$'\r'* | .. | ../* | */.. | */../*)
+    echo "unsafe ${name} path: ${value}" >&2
+    echo "${name} must be a relative path inside GITHUB_WORKSPACE without parent traversal." >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary
- hardens Nightward toward OpenSSF Passing/Silver-ready repository posture without cutting a release tag
- replaces short deterministic IDs with SHA-256-backed IDs while preserving the 12-hex shape
- tightens CI, composite action path handling, DCO checks, coverage gates, release snapshot validation, governance/security docs, and npm release readiness

## What changed
- Added `GOVERNANCE.md`, `MAINTAINERS.md`, `docs/threat-model.md`, and `docs/openssf-best-practices.md`.
- Expanded `SECURITY.md`, `CONTRIBUTING.md`, the PR template, README, roadmap, changelog, and testing/CI docs.
- Added DCO helper scripts and a read-only DCO PR workflow job.
- Scoped Trunk Flaky upload secrets to upload gates and added a checksum-verified Trunk CI installer.
- Hardened `action.yml` config/output path validation to reject absolute, traversal, newline, and backslash paths and keep writes inside `GITHUB_WORKSPACE`.
- Added `make coverage`, `make coverage-check`, `make ci-scripts-test`, and `make release-snapshot` with pinned Syft-backed SBOM snapshot support.
- Raised internal test coverage to the 80% gate with focused tests for analysis, CLI, fix plans, policy, schedule, snapshot, and TUI helpers.
- Added a release-gated npm launcher package under `packages/npm` with no `postinstall`, checksum verification, CI tests/audit/pack dry-run, and tag-gated publish workflow support.
- Updated Renovate custom managers/package rules for pinned local tooling and npm package metadata.

## Why
- Removes weak-crypto optics from deterministic IDs before 1.0.
- Gives the OpenSSF badge form canonical repo evidence and closes repo-controlled governance, review, security, coverage, and release-readiness gaps.
- Reduces CI/action path risk while preserving Nightward's local-first, no-telemetry, no-default-network-call trust boundary.
- Makes npm viable as a convenience install path without turning it into an unverified `postinstall` downloader.

## Validation
- `make verify`
- `make release-snapshot`
- `renovate-config-validator renovate.json`
- `npm audit --audit-level=moderate` in `integrations/raycast`
- `make npm-package-verify`
- `NIGHTWARD_BIN="$PWD/bin/nw" node packages/npm/bin/nightward.mjs --version`
- `go test ./cmd/... ./internal/... ./tools/...`
- `git diff --check`

## Notes
- No release tag was created.
- No npm package was published.
- Stable item/finding/signal IDs may change pre-1.0 because the backing hash moved from SHA-1 to SHA-256; ID length remains unchanged.
- Real release signing remains tag-driven and human-gated; snapshot validation skips signing but verifies archives, checksums, and SBOM generation.
- Npm publish is disabled unless `NPM_PUBLISH=true` and npm credentials/trusted publishing are configured.
