### PR TITLE
feat(analysis): harden online provider execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,9 +251,11 @@ Secret values are never emitted in scan JSON, findings output, fix-plan JSON, Ma
 
 `nw analyze` turns scan findings and classifications into explainable signals. It does not claim a package, server, binary, or URL is safe. It reports what Nightward can prove from local structure, why it matters, and how confident the signal is.
 
-Default analysis is offline and built in. Optional providers such as `gitleaks`, `trufflehog`, `semgrep`, `trivy`, `osv-scanner`, and `socket` are discovered by `providers doctor`; Nightward does not install them or call online services unless a user explicitly selects providers and opts into network-capable behavior. When explicitly selected with `--with`, supported local providers run with timeouts, output caps, and redacted metadata only. Semgrep execution requires a repo-local config file so Nightward does not use automatic rule discovery by default.
+Default analysis is offline and built in. Optional providers are discovered by `providers doctor`; Nightward does not install them or call online services unless a user explicitly selects providers and opts into network-capable behavior. Explicit local providers are `gitleaks`, `trufflehog`, and `semgrep`. Online-capable providers are `trivy`, `osv-scanner`, and `socket`, and they require both `--with` and `--online`. Socket support creates a remote Socket scan artifact from dependency manifest metadata; Nightward does not fetch or normalize remote Socket reports in v1.
 
-Policy config can enable analysis and selected local provider execution with `include_analysis`, `analysis_threshold`, `analysis_providers`, and `allow_online_providers`.
+Provider runs use timeouts, bounded output capture, and redacted metadata only. Semgrep execution requires a repo-local config file so Nightward does not use automatic rule discovery by default.
+
+Policy config can enable analysis and selected provider execution with `include_analysis`, `analysis_threshold`, `analysis_providers`, and `allow_online_providers`; online-capable providers still require explicit policy opt-in.
 
 ```mermaid
 sequenceDiagram

--- a/docs/analysis.md
+++ b/docs/analysis.md
@@ -20,14 +20,16 @@ Nightward avoids "safe" claims. A clean analysis means Nightward found no known 
 
 ## Providers
 
-The built-in `nightward` provider is always offline and enabled by default. Optional providers are discovered but not installed or run automatically:
+The built-in `nightward` provider is always offline and enabled by default. Optional providers are discovered but not installed or run automatically.
 
-- `gitleaks`
-- `trufflehog`
-- `semgrep`
-- `trivy`
-- `osv-scanner`
-- `socket`
+| Provider | Execution class | Required gate | Scope |
+| --- | --- | --- | --- |
+| `gitleaks` | local command | `--with gitleaks` | Secret pattern scanning over the selected workspace. |
+| `trufflehog` | local command | `--with trufflehog` | Filesystem secret scanning with verification disabled by default. |
+| `semgrep` | local command | `--with semgrep` | Static analysis using only a repo-local Semgrep config. |
+| `trivy` | online-capable command | `--with trivy --online` | Filesystem vulnerability, secret, and misconfiguration scan; Trivy may update vulnerability databases. |
+| `osv-scanner` | online-capable command | `--with osv-scanner --online` | Recursive source/lockfile vulnerability scan against OSV data. |
+| `socket` | online-capable command | `--with socket --online` | Creates a remote Socket scan artifact from dependency manifest metadata. |
 
 Check provider posture:
 
@@ -51,7 +53,7 @@ nw analyze --all --workspace . --with gitleaks --json
 nw analyze --all --workspace . --with gitleaks,trufflehog,semgrep --json
 ```
 
-Provider runs use timeouts and bounded output capture. Nightward records redacted finding metadata, not raw secret values. Online-capable providers such as `trivy`, `osv-scanner`, and `socket` stay blocked unless the user also opts into online-capable behavior.
+Provider runs use timeouts and bounded output capture. Nightward records redacted finding metadata, not raw secret values. Online-capable providers such as `trivy`, `osv-scanner`, and `socket` stay blocked unless the user also opts into online-capable behavior. Socket support is deliberately limited to scan creation and returned JSON parsing in v1; Nightward does not fetch or normalize remote Socket reports after creating the scan.
 
 `semgrep` execution is local-config only. Nightward looks for `semgrep.yml`, `semgrep.yaml`, `.semgrep.yml`, `.semgrep.yaml`, or `.semgrep/config.yml` in the scanned workspace instead of using automatic rule discovery.
 

--- a/docs/privacy-model.md
+++ b/docs/privacy-model.md
@@ -8,7 +8,7 @@ Nightward is designed around local custody. The scanner inspects local file meta
 - No analytics.
 - No cloud dashboard.
 - No network calls from Nightward runtime.
-- Offline analysis is the default. Local provider execution happens only when the user explicitly selects providers with `--with` or policy config. Online-capable providers stay blocked unless the user explicitly passes `--online` or opts in through policy/config.
+- Offline analysis is the default. Local provider execution happens only when the user explicitly selects providers with `--with` or policy config. Online-capable providers stay blocked unless the user explicitly passes `--online` or opts in through policy/config. `socket` is online-capable because it creates a remote Socket scan artifact from dependency manifest metadata.
 - No live backup, restore, Git push, or secret copy.
 - No agent config mutation in scan, doctor, findings, fix, policy, or backup-plan commands.
 - The TUI can copy text, export redacted fix-plan Markdown, and open docs only after explicit keypresses.
@@ -57,7 +57,7 @@ MCP argument evidence redacts secret-looking assignments and flag values, such a
 
 Remote MCP URL evidence is structural only. Nightward records scheme and host for review, strips path/query details, and does not call the endpoint.
 
-Provider doctor output is intentionally about availability and privacy posture. It does not run optional local scanners by default, install missing tools, or send package/file metadata to online services. Explicit local provider runs use timeouts, bounded output capture, and redacted finding metadata.
+Provider doctor output is intentionally about availability and privacy posture. It does not run optional scanners by default, install missing tools, or send package/file metadata to online services. Explicit provider runs use timeouts, bounded output capture, and redacted finding metadata; online-capable providers require `--online` or policy opt-in.
 
 ## What Still Needs Human Review
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -14,7 +14,7 @@ Nightward inspects local AI agent and devtool state, so its primary risk is acci
 
 - Local filesystem input is untrusted. Config files may be malformed, hostile, huge, symlinked, or privacy-sensitive.
 - CLI/TUI/Raycast output is a disclosure boundary. Secret values must not cross it.
-- Optional providers are execution boundaries. They are discovered but not installed or run online by default.
+- Optional providers are execution boundaries. They are discovered but not installed or run online by default. Socket is treated as online-capable because it creates a remote scan artifact from dependency manifest metadata.
 - GitHub Actions and Trunk integrations treat repository contents and PR input as untrusted.
 - Scheduler install/remove is an explicit write boundary and must stay user-level.
 - Release automation and npm publishing are privileged publishing boundaries.

--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -229,7 +229,7 @@ func Providers() []Provider {
 		{Name: "semgrep", Kind: "local-command", Command: "semgrep", Privacy: "local command; rule packs may require network if user config chooses that", Capabilities: "static analysis and malicious dependency rules"},
 		{Name: "trivy", Kind: "local-command", Command: "trivy", Online: true, Privacy: "network-capable; vulnerability database updates may contact upstream services", Capabilities: "filesystem, dependency, IaC, and secret scanning"},
 		{Name: "osv-scanner", Kind: "local-command", Command: "osv-scanner", Online: true, Privacy: "network-capable; queries vulnerability data for dependency manifests", Capabilities: "open source vulnerability matching"},
-		{Name: "socket", Kind: "local-command", Command: "socket", Online: true, Privacy: "network-capable; may send package metadata to Socket services", Capabilities: "supply-chain risk and malicious package signals"},
+		{Name: "socket", Kind: "local-command", Command: "socket", Online: true, Privacy: "network-capable; uploads dependency manifest metadata and creates a remote Socket scan artifact", Capabilities: "remote supply-chain scan creation and malicious package signals"},
 	}
 }
 

--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -200,7 +200,7 @@ func TestProviderParsersCoverSupportedFormats(t *testing.T) {
 		t.Fatalf("unexpected trivy parse: %#v", trivy)
 	}
 
-	osv, err := parseProviderOutput("osv-scanner", root, `{"results":[{"source":"/tmp/workspace/package-lock.json","packages":[{"package":{"name":"demo"},"vulnerabilities":[{"id":"GHSA-123","summary":"bad package"}]}]}]}`)
+	osv, err := parseProviderOutput("osv-scanner", root, `{"results":[{"source":{"path":"/tmp/workspace/package-lock.json","type":"lockfile"},"packages":[{"package":{"name":"demo"},"vulnerabilities":[{"id":"GHSA-123","summary":"bad package"}]}]}]}`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -231,6 +231,42 @@ func TestProviderParsersCoverSupportedFormats(t *testing.T) {
 	}
 }
 
+func TestOnlineProviderParsersRedactSecretLikeFields(t *testing.T) {
+	root := "/tmp/workspace"
+	cases := map[string]string{
+		"trivy":       `{"Results":[{"Target":"/tmp/workspace/package-lock.json","Vulnerabilities":[{"VulnerabilityID":"CVE-2026-0001","PkgName":"demo","Severity":"CRITICAL","Title":"API_TOKEN=super-secret-value vulnerable dependency"}],"Misconfigurations":[{"ID":"AVD-1","Severity":"MEDIUM","Title":"password=super-secret-value in config"}],"Secrets":[{"RuleID":"aws-access-key","Severity":"HIGH","Target":"/tmp/workspace/.env","Title":"private_key=super-secret-value"}]}]}`,
+		"osv-scanner": `{"results":[{"source":{"path":"/tmp/workspace/package-lock.json","type":"lockfile"},"packages":[{"package":{"name":"demo"},"vulnerabilities":[{"id":"GHSA-123","summary":"api_key=super-secret-value vulnerable package"}]}]},{"path":"/tmp/workspace/go.mod","vulnerabilities":[{"id":"GO-2026-0001","details":"password=super-secret-value detail"}]}]}`,
+		"socket":      `{"issues":[{"type":"malware","severity":"high","message":"API_TOKEN=super-secret-value","package":{"name":"demo"},"file":"package.json"}],"scanId":"scan_123"}`,
+	}
+	for provider, output := range cases {
+		findings, err := parseProviderOutput(provider, root, output)
+		if err != nil {
+			t.Fatalf("%s parse failed: %v", provider, err)
+		}
+		if len(findings) == 0 {
+			t.Fatalf("%s parse returned no findings", provider)
+		}
+		data, err := json.Marshal(findings)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(data), "super-secret-value") {
+			t.Fatalf("%s parser leaked provider secret material: %s", provider, data)
+		}
+		if !strings.Contains(string(data), "[redacted]") {
+			t.Fatalf("%s parser did not preserve redaction marker: %s", provider, data)
+		}
+	}
+}
+
+func TestOnlineProviderParsersRejectInvalidJSON(t *testing.T) {
+	for _, provider := range []string{"trivy", "osv-scanner", "socket"} {
+		if _, err := parseProviderOutput(provider, "/tmp/workspace", `{"not-json"`); err == nil {
+			t.Fatalf("%s parser accepted invalid JSON", provider)
+		}
+	}
+}
+
 func TestProviderHelpersAndOutputLimits(t *testing.T) {
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "semgrep.yml"), []byte("rules: []\n"), 0o600); err != nil {
@@ -246,6 +282,9 @@ func TestProviderHelpersAndOutputLimits(t *testing.T) {
 			t.Fatalf("missing online-capable provider args for %s: %#v ok=%t err=%v", name, args, ok, err)
 		}
 	}
+	assertStringSlice(t, "trivy args", []string{"filesystem", "--format", "json", "--scanners", "vuln,secret,misconfig", "--skip-version-check", root}, mustProviderArgs(t, "trivy", root))
+	assertStringSlice(t, "osv-scanner args", []string{"scan", "source", "-r", "--format", "json", root}, mustProviderArgs(t, "osv-scanner", root))
+	assertStringSlice(t, "socket args", []string{"scan", "create", root, "--json"}, mustProviderArgs(t, "socket", root))
 	if _, ok, err := providerArgs("semgrep", t.TempDir()); !ok || err == nil {
 		t.Fatalf("semgrep should require a local config, ok=%t err=%v", ok, err)
 	}
@@ -282,6 +321,33 @@ func TestProviderHelpersAndOutputLimits(t *testing.T) {
 	}
 	if got := providerRecommendation("semgrep", CategoryExecution); !strings.Contains(got, "semgrep") {
 		t.Fatalf("unexpected provider recommendation: %q", got)
+	}
+}
+
+func TestRunOnlineProviderTimeoutIsReportedAndRedacted(t *testing.T) {
+	dir := t.TempDir()
+	workspace := t.TempDir()
+	writeExecutable(t, filepath.Join(dir, "trivy"), `#!/bin/sh
+echo 'API_TOKEN=super-secret-value still running' >&2
+/bin/sleep 1
+`)
+	t.Setenv("PATH", dir)
+	oldTimeout := providerTimeout
+	providerTimeout = 10 * time.Millisecond
+	t.Cleanup(func() { providerTimeout = oldTimeout })
+
+	report := inventory.NewWorkspaceScanner(workspace).Scan()
+	out := Run(report, Options{Mode: "workspace", Workspace: workspace, With: []string{"trivy"}, Online: true})
+	data, err := json.Marshal(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "provider_execution_failed") || !strings.Contains(text, "timed out") {
+		t.Fatalf("timeout was not reported as a provider failure: %s", text)
+	}
+	if strings.Contains(text, "super-secret-value") {
+		t.Fatalf("timeout failure leaked provider stderr: %s", text)
 	}
 }
 
@@ -331,6 +397,27 @@ func writeExecutable(t *testing.T, path, contents string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(contents), 0700); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func mustProviderArgs(t *testing.T, name, root string) []string {
+	t.Helper()
+	args, ok, err := providerArgs(name, root)
+	if err != nil || !ok {
+		t.Fatalf("providerArgs(%s) ok=%t err=%v", name, ok, err)
+	}
+	return args
+}
+
+func assertStringSlice(t *testing.T, name string, want, got []string) {
+	t.Helper()
+	if len(want) != len(got) {
+		t.Fatalf("%s length mismatch\nwant=%#v\ngot=%#v", name, want, got)
+	}
+	for i := range want {
+		if want[i] != got[i] {
+			t.Fatalf("%s mismatch at %d\nwant=%#v\ngot=%#v", name, i, want, got)
+		}
 	}
 }
 

--- a/internal/analysis/providers.go
+++ b/internal/analysis/providers.go
@@ -16,9 +16,10 @@ import (
 )
 
 const (
-	providerTimeout        = 20 * time.Second
 	providerOutputMaxBytes = 2 * 1024 * 1024
 )
+
+var providerTimeout = 20 * time.Second
 
 type providerFinding struct {
 	Rule     string
@@ -150,6 +151,7 @@ func runProvider(name, root string) ([]providerFinding, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), providerTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, name, args...) // #nosec G204 -- provider name is selected from Nightward's built-in provider allowlist.
+	cmd.Dir = root
 	var stdout, stderr limitedBuffer
 	stdout.limit = providerOutputMaxBytes
 	stderr.limit = 64 * 1024
@@ -403,7 +405,7 @@ func parseOSVScanner(root, output string) ([]providerFinding, error) {
 	}
 	var findings []providerFinding
 	for _, result := range mapSlice(doc, "results", "Results") {
-		path := relativeProviderPath(root, firstString(result, "source", "path", "file", "lockfile"))
+		path := relativeProviderPath(root, providerSourcePath(result))
 		for _, pkg := range mapSlice(result, "packages", "Packages") {
 			pkgInfo, _ := pkg["package"].(map[string]any)
 			name := firstString(pkg, "name", "package", "PkgName")
@@ -460,6 +462,11 @@ func parseSocket(root, output string) ([]providerFinding, error) {
 			}
 			path := relativeProviderPath(root, firstString(issue, "file", "path", "manifest"))
 			pkg := firstString(issue, "package", "pkg", "name")
+			if pkg == "" {
+				if pkgInfo, ok := issue["package"].(map[string]any); ok {
+					pkg = firstString(pkgInfo, "name", "Name", "package")
+				}
+			}
 			evidence := fmt.Sprintf("rule=%s package=%s file=%s", redactProviderText(rule), redactProviderText(pkg), redactProviderText(path))
 			findings = append(findings, providerFinding{Rule: rule, Path: path, Message: redactProviderText(message), Evidence: evidence, Severity: providerSeverity(firstString(issue, "severity", "risk"), inventory.RiskMedium), Category: CategorySupplyChain})
 		}
@@ -495,9 +502,28 @@ func providerSeverity(value string, fallback inventory.RiskLevel) inventory.Risk
 	}
 }
 
+func providerSourcePath(record map[string]any) string {
+	if path := firstString(record, "source", "path", "file", "lockfile"); path != "" {
+		return path
+	}
+	for _, key := range []string{"source", "Source"} {
+		source, ok := record[key].(map[string]any)
+		if !ok {
+			continue
+		}
+		if path := firstString(source, "path", "Path", "file", "File", "lockfile", "Lockfile"); path != "" {
+			return path
+		}
+	}
+	return ""
+}
+
 func providerRecommendation(provider string, category SignalCategory) string {
 	if category == CategorySecrets {
 		return "Rotate exposed credentials if confirmed, remove secret material from portable config, and keep only local secret references."
+	}
+	if provider == "socket" {
+		return "Review the Socket scan artifact and package metadata locally before trusting or syncing this configuration."
 	}
 	return fmt.Sprintf("Review the %s finding locally before trusting or syncing this configuration.", provider)
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -436,18 +436,30 @@ func TestAnalyzeWithOnlineProvidersRequiresExplicitOnline(t *testing.T) {
 	writeTestFile(t, filepath.Join(workspace, "package.json"), `{"dependencies":{"demo":"1.0.0"}}`)
 	binDir := t.TempDir()
 	writeTestFile(t, filepath.Join(binDir, "trivy"), `#!/bin/sh
+if [ "$PWD" != "$7" ] || [ "$1" != "filesystem" ] || [ "$2" != "--format" ] || [ "$3" != "json" ] || [ "$4" != "--scanners" ] || [ "$5" != "vuln,secret,misconfig" ] || [ "$6" != "--skip-version-check" ]; then
+  echo "unexpected trivy args: $*" >&2
+  exit 2
+fi
 printf '{"Results":[{"Target":"package.json","Vulnerabilities":[{"VulnerabilityID":"CVE-2026-0001","PkgName":"demo","Severity":"HIGH","Title":"demo vulnerable"}]}]}'
 `)
 	if err := os.Chmod(filepath.Join(binDir, "trivy"), 0700); err != nil {
 		t.Fatal(err)
 	}
 	writeTestFile(t, filepath.Join(binDir, "osv-scanner"), `#!/bin/sh
+if [ "$PWD" != "$6" ] || [ "$1" != "scan" ] || [ "$2" != "source" ] || [ "$3" != "-r" ] || [ "$4" != "--format" ] || [ "$5" != "json" ]; then
+  echo "unexpected osv-scanner args: $*" >&2
+  exit 2
+fi
 printf '{"results":[{"source":"package.json","packages":[{"package":{"name":"demo"},"vulnerabilities":[{"id":"GHSA-123","summary":"bad package"}]}]}]}'
 `)
 	if err := os.Chmod(filepath.Join(binDir, "osv-scanner"), 0700); err != nil {
 		t.Fatal(err)
 	}
 	writeTestFile(t, filepath.Join(binDir, "socket"), `#!/bin/sh
+if [ "$PWD" != "$3" ] || [ "$1" != "scan" ] || [ "$2" != "create" ] || [ "$4" != "--json" ]; then
+  echo "unexpected socket args: $*" >&2
+  exit 2
+fi
 printf '{"issues":[{"type":"malware","severity":"high","message":"API_TOKEN=super-secret-value","package":"demo","file":"package.json"}]}'
 `)
 	if err := os.Chmod(filepath.Join(binDir, "socket"), 0700); err != nil {

--- a/site/guide/privacy-model.md
+++ b/site/guide/privacy-model.md
@@ -26,4 +26,6 @@ Scheduled scans write redacted reports under `~/.local/state/nightward/reports/`
 
 ## Optional providers
 
-Provider execution is opt-in. Online-capable providers require explicit `--online` or policy opt-in. Nightward should explain provider privacy impact before using tools that may contact external services.
+Provider execution is opt-in. Local providers (`gitleaks`, `trufflehog`, and repo-configured `semgrep`) require explicit `--with`. Online-capable providers (`trivy`, `osv-scanner`, and `socket`) require explicit `--with` plus `--online` or policy opt-in.
+
+`socket` creates a remote Socket scan artifact from dependency manifest metadata. Nightward records only redacted returned metadata and does not fetch remote Socket reports in v1.

--- a/site/security/threat-model.md
+++ b/site/security/threat-model.md
@@ -6,7 +6,7 @@ Nightward's primary asset is local AI/devtool state: config files, MCP server de
 
 - Local filesystem input is untrusted.
 - Config files may be malformed, hostile, huge, symlinked, or privacy-sensitive.
-- Optional providers may execute local tools and, if explicitly allowed, contact external services.
+- Optional providers may execute local tools and, if explicitly allowed, contact external services; Socket creates a remote scan artifact from dependency manifest metadata.
 - GitHub Actions and Trunk integrations treat repository contents and PR input as untrusted.
 - Release automation and npm publishing are privileged publishing boundaries.
 


### PR DESCRIPTION
## Summary
- closes the explicit online provider-runner gap for Trivy, OSV-Scanner, and Socket
- keeps all online-capable providers behind the existing provider selection plus online opt-in gates
- tightens parser/redaction coverage and documentation so Socket is presented as remote scan creation, not local-only analysis

## What changed
- runs explicit providers from the selected workspace with bounded output, timeouts, and redacted execution failures
- parses Trivy vulnerability/secret/misconfiguration output, OSV package and direct vulnerability shapes, and Socket issue plus scan-id responses
- adds online provider parser redaction tests, invalid JSON tests, timeout redaction coverage, and CLI fake-binary gate/no-write regressions
- updates README, docs, and site pages to distinguish local providers from online-capable providers

## Why
- the support matrix previously made the online provider surface look more complete and local-only than it really was
- v1 needs narrow, explicit execution behavior with no default network calls, no telemetry, and no workspace mutation

## Validation
- ok  	github.com/jsonbored/nightward/internal/analysis	(cached)
ok  	github.com/jsonbored/nightward/internal/cli	(cached)
- go test github.com/jsonbored/nightward/cmd/nightward github.com/jsonbored/nightward/cmd/nw github.com/jsonbored/nightward/internal/analysis github.com/jsonbored/nightward/internal/backupplan github.com/jsonbored/nightward/internal/cli github.com/jsonbored/nightward/internal/fixplan github.com/jsonbored/nightward/internal/inventory github.com/jsonbored/nightward/internal/policy github.com/jsonbored/nightward/internal/reporthtml github.com/jsonbored/nightward/internal/rules github.com/jsonbored/nightward/internal/schedule github.com/jsonbored/nightward/internal/snapshot github.com/jsonbored/nightward/internal/tui github.com/jsonbored/nightward/tools/normalize-go-junit
?   	github.com/jsonbored/nightward/cmd/nightward	[no test files]
?   	github.com/jsonbored/nightward/cmd/nw	[no test files]
ok  	github.com/jsonbored/nightward/internal/analysis	(cached)
ok  	github.com/jsonbored/nightward/internal/backupplan	(cached)
ok  	github.com/jsonbored/nightward/internal/cli	(cached)
ok  	github.com/jsonbored/nightward/internal/fixplan	(cached)
ok  	github.com/jsonbored/nightward/internal/inventory	(cached)
ok  	github.com/jsonbored/nightward/internal/policy	(cached)
ok  	github.com/jsonbored/nightward/internal/reporthtml	(cached)
ok  	github.com/jsonbored/nightward/internal/rules	(cached)
ok  	github.com/jsonbored/nightward/internal/schedule	(cached)
ok  	github.com/jsonbored/nightward/internal/snapshot	(cached)
ok  	github.com/jsonbored/nightward/internal/tui	(cached)
?   	github.com/jsonbored/nightward/tools/normalize-go-junit	[no test files]
go test -race github.com/jsonbored/nightward/cmd/nightward github.com/jsonbored/nightward/cmd/nw github.com/jsonbored/nightward/internal/analysis github.com/jsonbored/nightward/internal/backupplan github.com/jsonbored/nightward/internal/cli github.com/jsonbored/nightward/internal/fixplan github.com/jsonbored/nightward/internal/inventory github.com/jsonbored/nightward/internal/policy github.com/jsonbored/nightward/internal/reporthtml github.com/jsonbored/nightward/internal/rules github.com/jsonbored/nightward/internal/schedule github.com/jsonbored/nightward/internal/snapshot github.com/jsonbored/nightward/internal/tui github.com/jsonbored/nightward/tools/normalize-go-junit
?   	github.com/jsonbored/nightward/cmd/nightward	[no test files]
?   	github.com/jsonbored/nightward/cmd/nw	[no test files]
ok  	github.com/jsonbored/nightward/internal/analysis	(cached)
ok  	github.com/jsonbored/nightward/internal/backupplan	(cached)
ok  	github.com/jsonbored/nightward/internal/cli	(cached)
ok  	github.com/jsonbored/nightward/internal/fixplan	(cached)
ok  	github.com/jsonbored/nightward/internal/inventory	(cached)
ok  	github.com/jsonbored/nightward/internal/policy	(cached)
ok  	github.com/jsonbored/nightward/internal/reporthtml	(cached)
ok  	github.com/jsonbored/nightward/internal/rules	(cached)
ok  	github.com/jsonbored/nightward/internal/schedule	(cached)
ok  	github.com/jsonbored/nightward/internal/snapshot	(cached)
ok  	github.com/jsonbored/nightward/internal/tui	(cached)
?   	github.com/jsonbored/nightward/tools/normalize-go-junit	[no test files]
go vet github.com/jsonbored/nightward/cmd/nightward github.com/jsonbored/nightward/cmd/nw github.com/jsonbored/nightward/internal/analysis github.com/jsonbored/nightward/internal/backupplan github.com/jsonbored/nightward/internal/cli github.com/jsonbored/nightward/internal/fixplan github.com/jsonbored/nightward/internal/inventory github.com/jsonbored/nightward/internal/policy github.com/jsonbored/nightward/internal/reporthtml github.com/jsonbored/nightward/internal/rules github.com/jsonbored/nightward/internal/schedule github.com/jsonbored/nightward/internal/snapshot github.com/jsonbored/nightward/internal/tui github.com/jsonbored/nightward/tools/normalize-go-junit
go run honnef.co/go/tools/cmd/staticcheck@v0.7.0 github.com/jsonbored/nightward/cmd/nightward github.com/jsonbored/nightward/cmd/nw github.com/jsonbored/nightward/internal/analysis github.com/jsonbored/nightward/internal/backupplan github.com/jsonbored/nightward/internal/cli github.com/jsonbored/nightward/internal/fixplan github.com/jsonbored/nightward/internal/inventory github.com/jsonbored/nightward/internal/policy github.com/jsonbored/nightward/internal/reporthtml github.com/jsonbored/nightward/internal/rules github.com/jsonbored/nightward/internal/schedule github.com/jsonbored/nightward/internal/snapshot github.com/jsonbored/nightward/internal/tui github.com/jsonbored/nightward/tools/normalize-go-junit
go run github.com/securego/gosec/v2/cmd/gosec@v2.26.1 -exclude-generated -exclude-dir=integrations/raycast/node_modules -exclude-dir=integrations/raycast/dist ./...
Results:


Summary:
  Gosec  : dev
  Files  : 18
  Lines  : 7201
  Nosec  : 24
  Issues : 0

go run github.com/zricethezav/gitleaks/v8@v8.30.1 detect --source . --redact --no-banner
go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...
No vulnerabilities found.
go test ./internal/inventory -run=^$ -fuzz=FuzzMCPConfigParsing -fuzztime=10s
fuzz: elapsed: 0s, gathering baseline coverage: 0/1428 completed
fuzz: elapsed: 2s, gathering baseline coverage: 1428/1428 completed, now fuzzing with 12 workers
fuzz: elapsed: 3s, execs: 59012 (19680/sec), new interesting: 9 (total: 1437)
fuzz: elapsed: 6s, execs: 175263 (38769/sec), new interesting: 22 (total: 1450)
fuzz: elapsed: 9s, execs: 178254 (997/sec), new interesting: 23 (total: 1451)
fuzz: elapsed: 11s, execs: 178254 (0/sec), new interesting: 23 (total: 1451)
PASS
ok  	github.com/jsonbored/nightward/internal/inventory	11.873s
mkdir -p reports
go test ./internal/... -coverprofile=reports/coverage.out
ok  	github.com/jsonbored/nightward/internal/analysis	(cached)	coverage: 86.9% of statements
ok  	github.com/jsonbored/nightward/internal/backupplan	(cached)	coverage: 94.3% of statements
ok  	github.com/jsonbored/nightward/internal/cli	(cached)	coverage: 77.4% of statements
ok  	github.com/jsonbored/nightward/internal/fixplan	(cached)	coverage: 81.1% of statements
ok  	github.com/jsonbored/nightward/internal/inventory	(cached)	coverage: 91.3% of statements
ok  	github.com/jsonbored/nightward/internal/policy	(cached)	coverage: 91.0% of statements
ok  	github.com/jsonbored/nightward/internal/reporthtml	(cached)	coverage: 90.9% of statements
ok  	github.com/jsonbored/nightward/internal/rules	(cached)	coverage: 87.5% of statements
ok  	github.com/jsonbored/nightward/internal/schedule	(cached)	coverage: 81.9% of statements
ok  	github.com/jsonbored/nightward/internal/snapshot	(cached)	coverage: 88.9% of statements
ok  	github.com/jsonbored/nightward/internal/tui	(cached)	coverage: 81.5% of statements
go tool cover -func=reports/coverage.out | tee reports/coverage.txt
github.com/jsonbored/nightward/internal/analysis/analysis.go:112:	Run				87.5%
github.com/jsonbored/nightward/internal/analysis/analysis.go:206:	Explain				100.0%
github.com/jsonbored/nightward/internal/analysis/analysis.go:224:	Providers			100.0%
github.com/jsonbored/nightward/internal/analysis/analysis.go:236:	ProviderStatuses		91.9%
github.com/jsonbored/nightward/internal/analysis/analysis.go:300:	signalFromFinding		100.0%
github.com/jsonbored/nightward/internal/analysis/analysis.go:323:	signalFromItem			100.0%
github.com/jsonbored/nightward/internal/analysis/analysis.go:375:	categoryForRule			100.0%
github.com/jsonbored/nightward/internal/analysis/analysis.go:394:	finalize			92.3%
github.com/jsonbored/nightward/internal/analysis/analysis.go:414:	selectedProviders		100.0%
github.com/jsonbored/nightward/internal/analysis/analysis.go:427:	stableID			100.0%
github.com/jsonbored/nightward/internal/analysis/analysis.go:432:	riskRank			100.0%
github.com/jsonbored/nightward/internal/analysis/analysis.go:447:	RelativeWorkspacePath		83.3%
github.com/jsonbored/nightward/internal/analysis/analysis.go:458:	HumanProviderSummary		100.0%
github.com/jsonbored/nightward/internal/analysis/providers.go:39:	Write				100.0%
github.com/jsonbored/nightward/internal/analysis/providers.go:53:	String				100.0%
github.com/jsonbored/nightward/internal/analysis/providers.go:63:	appendProviderSignals		81.0%
github.com/jsonbored/nightward/internal/analysis/providers.go:103:	appendProviderSignal		75.0%
github.com/jsonbored/nightward/internal/analysis/providers.go:143:	runProvider			90.0%
github.com/jsonbored/nightward/internal/analysis/providers.go:170:	providerArgs			90.9%
github.com/jsonbored/nightward/internal/analysis/providers.go:193:	localSemgrepConfig		88.9%
github.com/jsonbored/nightward/internal/analysis/providers.go:227:	parseProviderOutput		87.5%
github.com/jsonbored/nightward/internal/analysis/providers.go:246:	parseGitleaks			80.0%
github.com/jsonbored/nightward/internal/analysis/providers.go:275:	parseTrufflehog			81.0%
github.com/jsonbored/nightward/internal/analysis/providers.go:305:	parseSemgrep			78.9%
github.com/jsonbored/nightward/internal/analysis/providers.go:334:	semgrepSeverity			100.0%
github.com/jsonbored/nightward/internal/analysis/providers.go:338:	parseTrivy			81.0%
github.com/jsonbored/nightward/internal/analysis/providers.go:398:	parseOSVScanner			84.4%
github.com/jsonbored/nightward/internal/analysis/providers.go:444:	parseSocket			88.5%
github.com/jsonbored/nightward/internal/analysis/providers.go:490:	providerSeverity		100.0%
github.com/jsonbored/nightward/internal/analysis/providers.go:505:	providerSourcePath		77.8%
github.com/jsonbored/nightward/internal/analysis/providers.go:521:	providerRecommendation		80.0%
github.com/jsonbored/nightward/internal/analysis/providers.go:531:	relativeProviderPath		83.3%
github.com/jsonbored/nightward/internal/analysis/providers.go:542:	firstString			100.0%
github.com/jsonbored/nightward/internal/analysis/providers.go:551:	firstNumber			50.0%
github.com/jsonbored/nightward/internal/analysis/providers.go:565:	mapSlice			100.0%
github.com/jsonbored/nightward/internal/analysis/providers.go:582:	nestedString			77.8%
github.com/jsonbored/nightward/internal/analysis/providers.go:597:	firstProviderLine		75.0%
github.com/jsonbored/nightward/internal/analysis/providers.go:605:	redactProviderText		75.0%
github.com/jsonbored/nightward/internal/backupplan/plan.go:44:		Build				100.0%
github.com/jsonbored/nightward/internal/backupplan/plan.go:82:		actionFor			85.7%
github.com/jsonbored/nightward/internal/backupplan/plan.go:99:		normalize			100.0%
github.com/jsonbored/nightward/internal/backupplan/plan.go:106:		targetName			83.3%
github.com/jsonbored/nightward/internal/backupplan/plan.go:116:		actionRank			100.0%
github.com/jsonbored/nightward/internal/cli/cli.go:45:			Run				100.0%
github.com/jsonbored/nightward/internal/cli/cli.go:49:			RunWithName			81.2%
github.com/jsonbored/nightward/internal/cli/cli.go:109:			runRules			85.7%
github.com/jsonbored/nightward/internal/cli/cli.go:160:			runReport			73.1%
github.com/jsonbored/nightward/internal/cli/cli.go:197:			runSnapshot			54.1%
github.com/jsonbored/nightward/internal/cli/cli.go:250:			runScan				88.2%
github.com/jsonbored/nightward/internal/cli/cli.go:275:			runDoctor			90.0%
github.com/jsonbored/nightward/internal/cli/cli.go:290:			runPlan				88.2%
github.com/jsonbored/nightward/internal/cli/cli.go:314:			runAdapters			50.0%
github.com/jsonbored/nightward/internal/cli/cli.go:338:			runFindings			78.6%
github.com/jsonbored/nightward/internal/cli/cli.go:380:			runFix				81.5%
github.com/jsonbored/nightward/internal/cli/cli.go:459:			runAnalyze			56.9%
github.com/jsonbored/nightward/internal/cli/cli.go:526:			runTrust			77.8%
github.com/jsonbored/nightward/internal/cli/cli.go:552:			runProviders			63.3%
github.com/jsonbored/nightward/internal/cli/cli.go:597:			runPolicy			85.6%
github.com/jsonbored/nightward/internal/cli/cli.go:729:			runSchedule			58.1%
github.com/jsonbored/nightward/internal/cli/cli.go:816:			doctor				100.0%
github.com/jsonbored/nightward/internal/cli/cli.go:838:			commandCheck			100.0%
github.com/jsonbored/nightward/internal/cli/cli.go:846:			pathCheck			80.0%
github.com/jsonbored/nightward/internal/cli/cli.go:862:			maybeWriteReport		76.2%
github.com/jsonbored/nightward/internal/cli/cli.go:893:			printHelp			100.0%
github.com/jsonbored/nightward/internal/cli/cli.go:934:			printScan			93.3%
github.com/jsonbored/nightward/internal/cli/cli.go:959:			printDoctor			85.7%
github.com/jsonbored/nightward/internal/cli/cli.go:971:			printBackupPlan			100.0%
github.com/jsonbored/nightward/internal/cli/cli.go:979:			printFindingsList		60.0%
github.com/jsonbored/nightward/internal/cli/cli.go:989:			printFindingExplain		95.0%
github.com/jsonbored/nightward/internal/cli/cli.go:1019:		printFixPlan			100.0%
github.com/jsonbored/nightward/internal/cli/cli.go:1029:		printPolicy			87.5%
github.com/jsonbored/nightward/internal/cli/cli.go:1043:		printAnalysis			83.3%
github.com/jsonbored/nightward/internal/cli/cli.go:1063:		printSignal			100.0%
github.com/jsonbored/nightward/internal/cli/cli.go:1081:		printSnapshotPlan		100.0%
github.com/jsonbored/nightward/internal/cli/cli.go:1089:		printSnapshotDiff		100.0%
github.com/jsonbored/nightward/internal/cli/cli.go:1102:		printSchedulePlan		100.0%
github.com/jsonbored/nightward/internal/cli/cli.go:1117:		fixSelector			88.2%
github.com/jsonbored/nightward/internal/cli/cli.go:1144:		scanReport			100.0%
github.com/jsonbored/nightward/internal/cli/cli.go:1151:		analyzeReport			100.0%
github.com/jsonbored/nightward/internal/cli/cli.go:1163:		splitCSV			100.0%
github.com/jsonbored/nightward/internal/cli/cli.go:1178:		flagsFirst			72.2%
github.com/jsonbored/nightward/internal/cli/cli.go:1204:		writeJSON			80.0%
github.com/jsonbored/nightward/internal/cli/cli.go:1213:		fail				100.0%
github.com/jsonbored/nightward/internal/cli/cli.go:1218:		expandHome			57.1%
github.com/jsonbored/nightward/internal/cli/cli.go:1231:		expandConfigPath		100.0%
github.com/jsonbored/nightward/internal/cli/cli.go:1238:		executablePath			50.0%
github.com/jsonbored/nightward/internal/fixplan/plan.go:58:		Build				83.3%
github.com/jsonbored/nightward/internal/fixplan/plan.go:88:		Find				80.0%
github.com/jsonbored/nightward/internal/fixplan/plan.go:106:		Markdown			90.9%
github.com/jsonbored/nightward/internal/fixplan/plan.go:152:		matches				80.0%
github.com/jsonbored/nightward/internal/fixplan/plan.go:162:		fromFinding			100.0%
github.com/jsonbored/nightward/internal/fixplan/plan.go:190:		statusRank			100.0%
github.com/jsonbored/nightward/internal/fixplan/plan.go:201:		riskRank			66.7%
github.com/jsonbored/nightward/internal/fixplan/preview.go:53:		BuildPreview			87.5%
github.com/jsonbored/nightward/internal/fixplan/preview.go:80:		PreviewMarkdown			88.0%
github.com/jsonbored/nightward/internal/fixplan/preview.go:114:		PreviewDiff			80.0%
github.com/jsonbored/nightward/internal/fixplan/preview.go:131:		previewFinding			78.9%
github.com/jsonbored/nightward/internal/fixplan/preview.go:174:		previewExternalizeSecret	68.4%
github.com/jsonbored/nightward/internal/fixplan/preview.go:204:		previewExternalizeHeader	63.6%
github.com/jsonbored/nightward/internal/fixplan/preview.go:223:		previewReplaceShellWrapper	82.4%
github.com/jsonbored/nightward/internal/fixplan/preview.go:247:		previewNarrowFilesystem		75.0%
github.com/jsonbored/nightward/internal/fixplan/preview.go:262:		previewManualReview		72.0%
github.com/jsonbored/nightward/internal/fixplan/preview.go:305:		parseMCPServer			70.0%
github.com/jsonbored/nightward/internal/fixplan/preview.go:339:		redactedHunk			100.0%
github.com/jsonbored/nightward/internal/fixplan/preview.go:353:		stringValue			66.7%
github.com/jsonbored/nightward/internal/fixplan/preview.go:360:		stringSlice			80.0%
github.com/jsonbored/nightward/internal/fixplan/preview.go:377:		redactArgs			92.9%
github.com/jsonbored/nightward/internal/fixplan/preview.go:398:		redactString			100.0%
github.com/jsonbored/nightward/internal/fixplan/preview.go:402:		secretAssignment		50.0%
github.com/jsonbored/nightward/internal/fixplan/preview.go:410:		secretFlag			75.0%
github.com/jsonbored/nightward/internal/fixplan/preview.go:418:		quoteStrings			100.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:34:		inspectMCP			100.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:103:		readMCPServers			84.6%
github.com/jsonbored/nightward/internal/inventory/mcp.go:127:		readJSONServers			100.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:142:		readTOMLServers			100.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:157:		readYAMLServers			100.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:172:		mapServers			95.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:198:		reviewFinding			100.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:233:		commandFindings			100.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:353:		envFindings			100.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:412:		headerFindings			96.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:472:		urlFindings			100.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:503:		argFindings			100.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:562:		narrowBroadArgs			87.5%
github.com/jsonbored/nightward/internal/inventory/mcp.go:576:		packageName			68.4%
github.com/jsonbored/nightward/internal/inventory/mcp.go:606:		packageBaseName			100.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:613:		flagLikelyHasValue		80.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:625:		hasPinnedPackage		100.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:637:		pinnedPackageArg		90.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:653:		hasArg				75.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:662:		simpleShellPassthrough		78.6%
github.com/jsonbored/nightward/internal/inventory/mcp.go:684:		quoteList			100.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:692:		looksEnvReference		75.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:706:		referencesBroadPath		85.7%
github.com/jsonbored/nightward/internal/inventory/mcp.go:719:		referencesTokenPath		100.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:729:		remoteEvidence			85.7%
github.com/jsonbored/nightward/internal/inventory/mcp.go:741:		redactURL			75.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:749:		structuralEvidence		85.7%
github.com/jsonbored/nightward/internal/inventory/mcp.go:761:		isLocalEndpoint			73.3%
github.com/jsonbored/nightward/internal/inventory/mcp.go:784:		envNameForHeader		85.7%
github.com/jsonbored/nightward/internal/inventory/mcp.go:795:		stringValue			100.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:802:		stringMap			100.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:814:		stringSlice			100.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:828:		redact				66.7%
github.com/jsonbored/nightward/internal/inventory/mcp.go:839:		redactArgs			100.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:843:		redactArgSlice			94.1%
github.com/jsonbored/nightward/internal/inventory/mcp.go:868:		secretAssignmentKey		100.0%
github.com/jsonbored/nightward/internal/inventory/mcp.go:877:		secretFlag			75.0%
github.com/jsonbored/nightward/internal/inventory/scanner.go:38:	NewScanner			75.0%
github.com/jsonbored/nightward/internal/inventory/scanner.go:46:	NewWorkspaceScanner		85.7%
github.com/jsonbored/nightward/internal/inventory/scanner.go:58:	Scan				97.4%
github.com/jsonbored/nightward/internal/inventory/scanner.go:132:	scanWorkspace			95.5%
github.com/jsonbored/nightward/internal/inventory/scanner.go:180:	now				66.7%
github.com/jsonbored/nightward/internal/inventory/scanner.go:187:	expand				40.0%
github.com/jsonbored/nightward/internal/inventory/scanner.go:197:	finalizeReport			95.0%
github.com/jsonbored/nightward/internal/inventory/scanner.go:228:	inspectPath			100.0%
github.com/jsonbored/nightward/internal/inventory/scanner.go:262:	stableID			100.0%
github.com/jsonbored/nightward/internal/inventory/scanner.go:267:	severityRank			83.3%
github.com/jsonbored/nightward/internal/inventory/scanner.go:282:	adapters			100.0%
github.com/jsonbored/nightward/internal/inventory/scanner.go:492:	workspaceAdapters		100.0%
github.com/jsonbored/nightward/internal/inventory/scanner.go:577:	portable			100.0%
github.com/jsonbored/nightward/internal/inventory/scanner.go:581:	portableDir			100.0%
github.com/jsonbored/nightward/internal/inventory/scanner.go:587:	machineLocal			100.0%
github.com/jsonbored/nightward/internal/inventory/scanner.go:591:	machineLocalMCP			100.0%
github.com/jsonbored/nightward/internal/inventory/scanner.go:597:	secret				100.0%
github.com/jsonbored/nightward/internal/inventory/scanner.go:601:	runtime				100.0%
github.com/jsonbored/nightward/internal/inventory/scanner.go:605:	appOwned			100.0%
github.com/jsonbored/nightward/internal/inventory/scanner.go:609:	findingID			100.0%
github.com/jsonbored/nightward/internal/policy/policy.go:113:		Check				100.0%
github.com/jsonbored/nightward/internal/policy/policy.go:117:		BuildBadge			100.0%
github.com/jsonbored/nightward/internal/policy/policy.go:146:		CheckWithOptions		93.5%
github.com/jsonbored/nightward/internal/policy/policy.go:203:		WriteSARIF			100.0%
github.com/jsonbored/nightward/internal/policy/policy.go:207:		WriteSARIFWithConfig		100.0%
github.com/jsonbored/nightward/internal/policy/policy.go:212:		WriteSARIFObject		77.8%
github.com/jsonbored/nightward/internal/policy/policy.go:226:		WriteBadge			77.8%
github.com/jsonbored/nightward/internal/policy/policy.go:240:		BuildSARIF			100.0%
github.com/jsonbored/nightward/internal/policy/policy.go:244:		BuildSARIFWithConfig		100.0%
github.com/jsonbored/nightward/internal/policy/policy.go:248:		BuildSARIFWithAnalysis		100.0%
github.com/jsonbored/nightward/internal/policy/policy.go:303:		DefaultConfig			100.0%
github.com/jsonbored/nightward/internal/policy/policy.go:316:		DefaultConfigYAML		75.0%
github.com/jsonbored/nightward/internal/policy/policy.go:324:		Explain				100.0%
github.com/jsonbored/nightward/internal/policy/policy.go:349:		LoadConfig			78.6%
github.com/jsonbored/nightward/internal/policy/policy.go:370:		ValidateConfig			80.0%
github.com/jsonbored/nightward/internal/policy/policy.go:396:		sarifRules			100.0%
github.com/jsonbored/nightward/internal/policy/policy.go:435:		sarifSignalRules		100.0%
github.com/jsonbored/nightward/internal/policy/policy.go:475:		sarifResult			100.0%
github.com/jsonbored/nightward/internal/policy/policy.go:504:		sarifSignalResult		100.0%
github.com/jsonbored/nightward/internal/policy/policy.go:537:		ignoreReason			85.7%
github.com/jsonbored/nightward/internal/policy/policy.go:563:		artifactURI			80.0%
github.com/jsonbored/nightward/internal/policy/policy.go:573:		sarifLevel			100.0%
github.com/jsonbored/nightward/internal/policy/policy.go:584:		riskRank			100.0%
github.com/jsonbored/nightward/internal/policy/policy.go:599:		validRisk			66.7%
github.com/jsonbored/nightward/internal/reporthtml/report.go:23:	Render				87.5%
github.com/jsonbored/nightward/internal/reporthtml/report.go:46:	limitItems			100.0%
github.com/jsonbored/nightward/internal/rules/rules.go:20:		List				100.0%
github.com/jsonbored/nightward/internal/rules/rules.go:38:		Find				83.3%
github.com/jsonbored/nightward/internal/schedule/schedule.go:51:	BuildPlan			100.0%
github.com/jsonbored/nightward/internal/schedule/schedule.go:55:	BuildPlanForOS			89.3%
github.com/jsonbored/nightward/internal/schedule/schedule.go:106:	Status				87.5%
github.com/jsonbored/nightward/internal/schedule/schedule.go:125:	Install				56.0%
github.com/jsonbored/nightward/internal/schedule/schedule.go:163:	Remove				53.3%
github.com/jsonbored/nightward/internal/schedule/schedule.go:191:	launchdPlist			96.2%
github.com/jsonbored/nightward/internal/schedule/schedule.go:221:	systemdService			100.0%
github.com/jsonbored/nightward/internal/schedule/schedule.go:232:	systemdTimer			100.0%
github.com/jsonbored/nightward/internal/schedule/schedule.go:245:	cronLine			100.0%
github.com/jsonbored/nightward/internal/schedule/schedule.go:249:	shellJoin			100.0%
github.com/jsonbored/nightward/internal/schedule/schedule.go:261:	xmlEscape			75.0%
github.com/jsonbored/nightward/internal/schedule/schedule.go:269:	fileExists			100.0%
github.com/jsonbored/nightward/internal/schedule/schedule.go:274:	lastReport			100.0%
github.com/jsonbored/nightward/internal/schedule/schedule.go:283:	ReportHistory			94.1%
github.com/jsonbored/nightward/internal/schedule/schedule.go:315:	countFindings			75.0%
github.com/jsonbored/nightward/internal/snapshot/snapshot.go:59:	Build				90.9%
github.com/jsonbored/nightward/internal/snapshot/snapshot.go:85:	Load				85.7%
github.com/jsonbored/nightward/internal/snapshot/snapshot.go:97:	Compare				87.0%
github.com/jsonbored/nightward/internal/snapshot/snapshot.go:129:	indexEntries			100.0%
github.com/jsonbored/nightward/internal/tui/tui.go:87:			Run				0.0%
github.com/jsonbored/nightward/internal/tui/tui.go:92:			Init				0.0%
github.com/jsonbored/nightward/internal/tui/tui.go:96:			Update				82.9%
github.com/jsonbored/nightward/internal/tui/tui.go:212:			View				88.9%
github.com/jsonbored/nightward/internal/tui/tui.go:238:			renderTabs			91.7%
github.com/jsonbored/nightward/internal/tui/tui.go:257:			renderBody			100.0%
github.com/jsonbored/nightward/internal/tui/tui.go:274:			dashboard			85.7%
github.com/jsonbored/nightward/internal/tui/tui.go:325:			inventory			92.9%
github.com/jsonbored/nightward/internal/tui/tui.go:345:			findings			92.0%
github.com/jsonbored/nightward/internal/tui/tui.go:383:			fixPlan				92.0%
github.com/jsonbored/nightward/internal/tui/tui.go:421:			analysis			88.5%
github.com/jsonbored/nightward/internal/tui/tui.go:460:			backupPlan			100.0%
github.com/jsonbored/nightward/internal/tui/tui.go:483:			filteredFindings		91.7%
github.com/jsonbored/nightward/internal/tui/tui.go:503:			findingMatchesSearch		100.0%
github.com/jsonbored/nightward/internal/tui/tui.go:519:			help				100.0%
github.com/jsonbored/nightward/internal/tui/tui.go:538:			currentSignal			71.4%
github.com/jsonbored/nightward/internal/tui/tui.go:550:			currentFinding			71.4%
github.com/jsonbored/nightward/internal/tui/tui.go:562:			currentItem			83.3%
github.com/jsonbored/nightward/internal/tui/tui.go:573:			currentFix			71.4%
github.com/jsonbored/nightward/internal/tui/tui.go:585:			currentBackupEntry		71.4%
github.com/jsonbored/nightward/internal/tui/tui.go:597:			copySelection			87.5%
github.com/jsonbored/nightward/internal/tui/tui.go:630:			nextActions			27.3%
github.com/jsonbored/nightward/internal/tui/tui.go:652:			reportDelta			100.0%
github.com/jsonbored/nightward/internal/tui/tui.go:667:			currentDocsURL			44.4%
github.com/jsonbored/nightward/internal/tui/tui.go:686:			ruleDocsURL			66.7%
github.com/jsonbored/nightward/internal/tui/tui.go:693:			findingCopyText			28.6%
github.com/jsonbored/nightward/internal/tui/tui.go:706:			fixCopyText			40.0%
github.com/jsonbored/nightward/internal/tui/tui.go:716:			findingDetail			92.9%
github.com/jsonbored/nightward/internal/tui/tui.go:745:			signalDetail			90.0%
github.com/jsonbored/nightward/internal/tui/tui.go:767:			fixDetail			93.3%
github.com/jsonbored/nightward/internal/tui/tui.go:797:			copyToClipboardCmd		80.0%
github.com/jsonbored/nightward/internal/tui/tui.go:806:			openURLCmd			75.0%
github.com/jsonbored/nightward/internal/tui/tui.go:814:			exportFixPlanCmd		80.0%
github.com/jsonbored/nightward/internal/tui/tui.go:824:			actionStatusCmd			0.0%
github.com/jsonbored/nightward/internal/tui/tui.go:830:			runActionCommand		25.0%
github.com/jsonbored/nightward/internal/tui/tui.go:839:			clipboardCommand		100.0%
github.com/jsonbored/nightward/internal/tui/tui.go:843:			clipboardCommandFor		57.1%
github.com/jsonbored/nightward/internal/tui/tui.go:867:			openURLCommand			100.0%
github.com/jsonbored/nightward/internal/tui/tui.go:871:			openURLCommandFor		60.0%
github.com/jsonbored/nightward/internal/tui/tui.go:891:			exportFixPlan			75.0%
github.com/jsonbored/nightward/internal/tui/tui.go:909:			redactTUIText			100.0%
github.com/jsonbored/nightward/internal/tui/tui.go:914:			riskOptions			100.0%
github.com/jsonbored/nightward/internal/tui/tui.go:922:			toolOptions			100.0%
github.com/jsonbored/nightward/internal/tui/tui.go:930:			ruleOptions			100.0%
github.com/jsonbored/nightward/internal/tui/tui.go:938:			unique				87.5%
github.com/jsonbored/nightward/internal/tui/tui.go:951:			cycle				70.0%
github.com/jsonbored/nightward/internal/tui/tui.go:969:			filterLabel			100.0%
github.com/jsonbored/nightward/internal/tui/tui.go:976:			section				100.0%
github.com/jsonbored/nightward/internal/tui/tui.go:980:			metricLine			100.0%
github.com/jsonbored/nightward/internal/tui/tui.go:984:			byteSize			80.0%
github.com/jsonbored/nightward/internal/tui/tui.go:994:			severityColor			100.0%
github.com/jsonbored/nightward/internal/tui/tui.go:1007:		maxRisk				100.0%
github.com/jsonbored/nightward/internal/tui/tui.go:1017:		rank				66.7%
github.com/jsonbored/nightward/internal/tui/tui.go:1032:		fitLines			100.0%
github.com/jsonbored/nightward/internal/tui/tui.go:1040:		truncate			85.7%
github.com/jsonbored/nightward/internal/tui/tui.go:1062:		clampCursor			87.5%
github.com/jsonbored/nightward/internal/tui/tui.go:1076:		max				66.7%
total:									(statements)			83.8%
python3 -c 'import pathlib, re, sys; text=pathlib.Path("reports/coverage.txt").read_text(); match=re.search(r"total:\s+\(statements\)\s+([0-9.]+)%", text); pct=float(match.group(1)) if match else -1; threshold=float("83.0"); print(f"coverage {pct:.1f}% / threshold {threshold:.1f}%"); sys.exit(0 if pct >= threshold else 1)'
coverage 83.8% / threshold 83.0%
rm -rf reports
mkdir -p reports
go run gotest.tools/gotestsum@v1.13.0 --format testname --junitfile reports/go-tests.raw.xml -- github.com/jsonbored/nightward/cmd/nightward github.com/jsonbored/nightward/cmd/nw github.com/jsonbored/nightward/internal/analysis github.com/jsonbored/nightward/internal/backupplan github.com/jsonbored/nightward/internal/cli github.com/jsonbored/nightward/internal/fixplan github.com/jsonbored/nightward/internal/inventory github.com/jsonbored/nightward/internal/policy github.com/jsonbored/nightward/internal/reporthtml github.com/jsonbored/nightward/internal/rules github.com/jsonbored/nightward/internal/schedule github.com/jsonbored/nightward/internal/snapshot github.com/jsonbored/nightward/internal/tui github.com/jsonbored/nightward/tools/normalize-go-junit
EMPTY cmd/nightward
EMPTY cmd/nw
PASS internal/analysis.TestAnalysisBuildsOfflineSignalsAndRedacts (0.01s)
PASS internal/analysis.TestProviderDoctorHonorsOnlineGate (0.00s)
PASS internal/analysis.TestProviderDoctorEnablesOnlineProvidersOnlyWithOnlineOptIn (0.00s)
PASS internal/analysis.TestProviderDoctorFindsFakeLocalProvider (0.00s)
PASS internal/analysis.TestRunExecutesExplicitLocalProviderAndRedacts (0.60s)
PASS internal/analysis.TestRunReportsProviderExecutionFailureAsSignal (0.26s)
PASS internal/analysis.TestProviderParsersCoverSupportedFormats (0.01s)
PASS internal/analysis.TestOnlineProviderParsersRedactSecretLikeFields (0.00s)
PASS internal/analysis.TestOnlineProviderParsersRejectInvalidJSON (0.00s)
PASS internal/analysis.TestProviderHelpersAndOutputLimits (0.00s)
PASS internal/analysis.TestRunOnlineProviderTimeoutIsReportedAndRedacted (0.01s)
PASS internal/analysis.TestExplainRelativePathAndHumanProviderSummary (0.00s)
PASS internal/analysis.TestAnalysisItemCategoriesAndRiskRanks (0.00s)
PASS internal/analysis (cached)
PASS internal/backupplan.TestBuildClassifiesActions (0.00s)
PASS internal/backupplan (cached)
PASS internal/cli.TestReadOnlyCommandsDoNotMutateHome (0.04s)
PASS internal/cli.TestPublicCommandMatrixAndRedaction (0.03s)
PASS internal/cli.TestReportHTMLCommandWritesPrivateReport (0.01s)
PASS internal/fixplan.TestBuildGroupsFixStatusesAndRedacts (0.01s)
PASS internal/fixplan.TestBuildPreviewProducesRedactedPatchForInlineSecret (0.01s)
PASS internal/fixplan.TestBuildPreviewProducesRedactedPatchForInlineHeaderSecret (0.00s)
PASS internal/fixplan.TestBuildPreviewProducesReviewDiffsForEndpointAndFilesystemScope (0.00s)
PASS internal/fixplan.TestBuildPreviewProducesReviewDiffForCredentialPath (0.00s)
PASS internal/fixplan.TestBuildPreviewDoesNotGuessPackageVersions (0.00s)
PASS internal/fixplan.TestBuildPreviewReplacesSimpleShellWrapperAndRedactsArgs (0.00s)
PASS internal/fixplan.TestBuildPreviewExplainsUnpatchableSecretShapes (0.00s)
PASS internal/fixplan.TestPreviewMarkdownAndDiffEmptySelection (0.00s)
PASS internal/cli.TestHelpVersionAndCommandErrors (0.00s)
PASS internal/fixplan.TestSelectorFiltersFindings (0.00s)
PASS internal/fixplan (cached)
PASS internal/cli.TestScanOutputModesHaveEquivalentSummaries (0.01s)
PASS internal/cli.TestWorkspaceCommandsAreReadOnlyAndSupportStdoutSARIF (0.01s)
PASS internal/cli.TestPolicyBadgeWritesArtifactWithoutFailingPolicy (0.00s)
PASS internal/snapshot.TestBuildCreatesReadOnlySnapshotPlan (0.00s)
PASS internal/snapshot.TestCompareReportsAddedRemovedAndChangedEntries (0.00s)
PASS internal/inventory.TestGoldenScanSummaryAndURLFindings (0.02s)
PASS internal/cli.TestPolicyBadgeDoesNotRunConfiguredProvidersUnlessAnalysisIncluded (0.33s)
PASS internal/cli.TestAnalyzeWithExplicitProviderIsReadOnly (0.53s)
PASS internal/policy.TestCheckUsesStrictThreshold (0.00s)
PASS internal/inventory.TestPackageNameStripsMovingLatestTag (0.00s)
PASS internal/rules.TestListRulesSorted (0.00s)
PASS internal/policy.TestLoadConfigRejectsUnknownKeysAndReasonlessIgnores (0.01s)
PASS internal/rules.TestFindRule (0.00s)
PASS internal/rules.TestFindAmbiguousPrefix (0.00s)
PASS internal/policy.TestDefaultConfigExplainValidateAndWriteSARIF (0.01s)
PASS internal/policy.TestCheckWithConfigIgnoresWithReasonAndOverridesThreshold (0.00s)
PASS internal/cli.TestAnalyzeWithOnlineProvidersRequiresExplicitOnline (0.41s)
PASS internal/inventory.TestHasPinnedPackageRejectsLatest (0.00s)
PASS internal/snapshot.TestLoadSnapshotPlan (0.01s)
PASS internal/schedule.TestBuildPlanForDarwin (0.01s)
PASS internal/cli.TestWorkspaceScanDoesNotReadHomeFixtures (0.00s)
PASS internal/tui.TestFindingsAndFixPlanViewsRenderRedactedDetails (0.01s)
PASS internal/policy.TestSARIFRedactsAndIncludesFixMetadata (0.00s)
PASS internal/reporthtml.TestRenderEscapesHTML (0.01s)
PASS internal/reporthtml.TestRenderHandlesEmptyAndLimitsInventorySample (0.00s)
PASS internal/reporthtml (cached)
PASS internal/inventory.TestRedactArgsRedactsSecretFlagValues (0.00s)
PASS internal/rules (cached)
PASS internal/inventory.TestScannerFindsMCPRisksAndRedactsValues (0.00s)
PASS internal/inventory.TestScannerHandlesRemoteURLMCPShapesAndHeaders (0.00s)
PASS internal/inventory.TestScannerRedactsSecretArgumentValues (0.00s)
PASS internal/inventory.TestScannerDoesNotWriteToHome (0.00s)
PASS internal/cli.TestFixPlanFindingSelectorRequiresUniquePrefix (0.00s)
PASS internal/cli.TestPolicyCheckUsesConfig (0.00s)
PASS internal/tui.TestFindingSearchAndHelpRender (0.00s)
PASS internal/cli.TestHumanPrintersCoverPolicySnapshotAndSchedule (0.00s)
PASS internal/cli.TestHumanAnalysisSignalPrinter (0.00s)
PASS internal/tui.TestTUIActionSelectionAndDocsURL (0.00s)
PASS internal/policy.TestSARIFUsesConfigMetadataAndIgnores (0.00s)
PASS internal/schedule.TestBuildPlanForLinux (0.08s)
PASS internal/inventory.TestWorkspaceScannerFindsRepoAIConfigAndSecrets (0.00s)
PASS internal/inventory.TestScannerParsesYAMLMCPShapes (0.00s)
PASS internal/inventory.TestWorkspaceScannerFindsExpandedCommunityShapes (0.00s)
PASS internal/inventory.TestScannerHandlesMalformedHugeAndSymlinkMCPFixtures (0.01s)
PASS internal/inventory.TestScannerFindsExpandedAdaptersWithConservativeClassifications (0.01s)
PASS internal/inventory.FuzzMCPConfigParsing/seed#0 (0.00s)
PASS internal/inventory.FuzzMCPConfigParsing/seed#1 (0.00s)
PASS internal/inventory.FuzzMCPConfigParsing/seed#2 (0.00s)
PASS internal/inventory.FuzzMCPConfigParsing (0.01s)
PASS internal/inventory (cached)
PASS internal/snapshot (cached)
EMPTY tools/normalize-go-junit
PASS internal/policy.TestPolicyCanIncludeAnalysisSignals (0.00s)
PASS internal/policy.TestGoldenSARIFForURLSecurityFindings (0.00s)
PASS internal/policy.TestGoldenSARIFForAnalysisSignals (0.00s)
PASS internal/policy (cached)
PASS internal/schedule.TestBuildPlanForUnsupportedOSReturnsCronTextOnly (0.08s)
PASS internal/schedule.TestBuildPlanRejectsUnsupportedPreset (0.00s)
PASS internal/schedule.TestInstallAndRemoveUseGeneratedFilesWithoutSystemMutation (0.12s)
PASS internal/schedule.TestScheduleHelperProcess (0.00s)
PASS internal/schedule.TestStatusReadsLatestReportAndFindingCount (0.00s)
PASS internal/schedule.TestEscapingHelpers (0.00s)
PASS internal/schedule (cached)
PASS internal/cli (cached)
PASS internal/tui.TestTUIUpdateFiltersSearchAndHelp (0.01s)
PASS internal/tui.TestTUIUpdateNavigationAndActionBranches (0.01s)
PASS internal/tui.TestTUIViewResponsiveWidths (0.01s)
PASS internal/tui.TestTUIReportDeltaAndUtilityFallbacks (0.00s)
PASS internal/tui.TestDashboardShowsReportHistoryAndNextActions (0.00s)
PASS internal/tui.TestExportFixPlanWritesRedactedMarkdown (0.00s)
PASS internal/tui.TestClipboardAndOpenCommandBuilders (0.00s)
PASS internal/tui.TestTUISelectionsForSignalFixAndBackup (0.00s)
PASS internal/tui.TestTUIFiltersAndCursorHelpers (0.00s)
PASS internal/tui (cached)

DONE 93 tests in 0.197s
go run ./tools/normalize-go-junit reports/go-tests.raw.xml reports/go-tests.xml
cd integrations/raycast && npm ci --ignore-scripts --no-audit

added 170 packages in 2s

47 packages are looking for funding
  run `npm fund` for details
cd integrations/raycast && npm run test:junit

> nightward@0.1.0 test:junit
> mkdir -p ../../reports/junit && node --import tsx --test --test-reporter=spec --test-reporter=junit --test-reporter-destination=stdout --test-reporter-destination=../../reports/junit/raycast.raw.xml test/*.test.ts && node scripts/normalize-junit.mjs ../../reports/junit/raycast.raw.xml ../../reports/junit/raycast.xml

✔ redacts obvious secret assignments and long token-like values (1.212ms)
✔ finding markdown keeps guidance while avoiding secret values (0.854917ms)
✔ markdown helpers preserve escaped evidence without leaking formatting (0.18275ms)
✔ findings sort by severity then stable identity (2.053625ms)
✔ analysis markdown redacts signal evidence (0.517ms)
✔ normalizes empty preferences to nw without a home override (1.073833ms)
✔ passes NIGHTWARD_HOME and parses JSON output (1.96075ms)
✔ falls back from nw to nightward when nw is missing (1.613667ms)
✔ reports directory follows the optional home override (0.104ms)
ℹ tests 9
ℹ suites 0
ℹ pass 9
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 318.477875
trunk flakytests validate --junit-paths reports/go-tests.xml,reports/junit/raycast.xml
trunk check --show-existing --all
[0G[2K[0G[2K[0G[2K[0G[2K[0G
Checked 153 files
[1m[92m✔ No issues[0m
bash scripts/test-dco.sh
DCO fixture tests passed.
bash scripts/test-action-paths.sh
action path fixture tests passed.
bash scripts/test-release-scripts.sh
release script fixture tests passed.
cd integrations/raycast && npm audit --audit-level=moderate
found 0 vulnerabilities
cd integrations/raycast && npm run lint

> nightward@0.1.0 lint
> ray lint

ready  - validate package.json file
ready  - validate extension icons
ready  - validate extension metadata
ready  - run ESLint
ready  - run Prettier 3.8.3
cd integrations/raycast && npm run build

> nightward@0.1.0 build
> ray build -e dist

info  - entry points ["src/dashboard.tsx","src/findings.tsx","src/analysis.tsx","src/provider-doctor.tsx","src/explain-finding.tsx","src/explain-signal.tsx","src/export-fix-plan.ts","src/export-analysis.ts","src/open-report-folder.ts"]
info  - compiled entry points
info  - generated extension's TypeScript definitions
info  - checked TypeScript
ready  - built extension successfully
cd packages/npm && npm ci --ignore-scripts --no-audit

up to date in 120ms
cd packages/npm && npm test

> nightward@0.0.0-development test
> node --test test/*.test.mjs

✔ maps supported platforms to GoReleaser asset names (0.614875ms)
✔ rejects unsupported npm launcher platforms (0.1685ms)
✔ parses checksums by archive basename (0.192583ms)
✔ verifies archive sha256 before extraction (2.912791ms)
✔ uses invocation name and environment overrides (0.189875ms)
ℹ tests 5
ℹ suites 0
ℹ pass 5
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 83.895958
cd packages/npm && npm audit --audit-level=moderate
found 0 vulnerabilities
cd packages/npm && npm run pack:dry-run

> nightward@0.0.0-development pack:dry-run
> npm pack --dry-run

nightward-0.0.0-development.tgz
cd site && npm ci --ignore-scripts --no-audit

added 104 packages in 821ms

37 packages are looking for funding
  run `npm fund` for details
cd site && npm audit --audit-level=moderate
found 0 vulnerabilities
cd site && npm run build

> @jsonbored/nightward-site@0.0.0-development build
> vitepress build .


  vitepress v2.0.0-alpha.17

build complete in 1.52s.
- go install github.com/anchore/syft/cmd/syft@v1.43.0
PATH="$(go env GOPATH)/bin:$PATH" go run github.com/goreleaser/goreleaser/v2@v2.9.0 release --snapshot --clean --skip=publish,sign
- found 0 vulnerabilities
- found 0 vulnerabilities

## Notes
- no npm publish, release tag, or release artifact publication was performed
- Socket remains limited to creating a remote Socket scan artifact and parsing returned JSON; Nightward does not fetch remote Socket reports in v1