### PR TITLE
build(npm): publish scoped Nightward launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ This installs:
 After the first tagged release, Nightward will also ship a release-gated npm launcher:
 
 ```sh
-npx nightward --help
-npm install -g nightward
+npx @jsonbored/nightward --help
+npm install -g @jsonbored/nightward
 nw scan --json
 ```
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -5,7 +5,7 @@ Nightward distribution should optimize for trust first, then convenience.
 ## Order
 
 1. GitHub Releases with signed checksums and SBOMs.
-2. npm launcher with trusted publishing and provenance.
+2. scoped npm launcher `@jsonbored/nightward` with trusted publishing and provenance.
 3. `go install github.com/jsonbored/nightward/cmd/nw@vX.Y.Z`.
 4. Trunk plugin import from a release tag.
 5. GitHub Action release tags.
@@ -18,7 +18,7 @@ Docker is deferred until Nightward has a useful local report browser. A containe
 
 ## NPM Posture
 
-The npm package must remain a launcher:
+The npm package is `@jsonbored/nightward`. It must remain a launcher:
 
 - no `postinstall`
 - no bundled second implementation

--- a/docs/install.md
+++ b/docs/install.md
@@ -26,7 +26,7 @@ Users who want the strongest supply-chain verification should download from GitH
 
 ## NPM
 
-The `nightward` npm package name is available and this repo includes a release-gated package under `packages/npm`.
+The npm registry rejected the unscoped `nightward` package name as too similar to an existing package, so Nightward publishes the scoped package `@jsonbored/nightward`. The installed binaries are still `nightward` and `nw`.
 
 The package is a thin launcher:
 
@@ -39,12 +39,12 @@ The package is a thin launcher:
 Example after the first release is published:
 
 ```sh
-npx nightward --help
-npm install -g nightward
+npx @jsonbored/nightward --help
+npm install -g @jsonbored/nightward
 nw scan --json
 ```
 
-Publishing is disabled by default. The release workflow publishes to npm only when `NPM_PUBLISH=true` is configured and npm trusted publishing is ready for package `nightward`, repository `JSONbored/nightward`, and workflow `.github/workflows/release.yml`.
+Publishing is disabled by default. The release workflow publishes to npm only when `NPM_PUBLISH=true` is configured and npm trusted publishing is ready for package `@jsonbored/nightward`, repository `JSONbored/nightward`, and workflow `.github/workflows/release.yml`.
 
 The package should not use a long-lived npm token. It should publish through GitHub OIDC/trusted publishing with provenance.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -24,7 +24,7 @@ Use these repository settings before the first public release:
 - Protect release tags from force-push and deletion.
 - Require signed tags for releases.
 - Use a protected `npm-publish` environment with at least one reviewer.
-- Configure npm trusted publishing for package `nightward`, repository `JSONbored/nightward`, workflow `.github/workflows/release.yml`.
+- Configure npm trusted publishing for package `@jsonbored/nightward`, repository `JSONbored/nightward`, workflow `.github/workflows/release.yml`.
 
 ## Tagging
 
@@ -62,7 +62,7 @@ sha256sum -c checksums.txt --ignore-missing
 
 The npm package is release-gated, trusted-publishing only, and disabled by default. To publish it:
 
-1. Configure npm trusted publishing for package `nightward`.
+1. Configure npm trusted publishing for package `@jsonbored/nightward`.
 2. Set repository variable `NPM_PUBLISH=true`.
 3. Push a reviewed, signed release tag.
 
@@ -73,10 +73,10 @@ The npm package should remain a launcher for GitHub Release binaries. Do not add
 After publish, verify:
 
 ```sh
-npm view nightward version dist.integrity repository
-npm view nightward --json | jq '.dist'
-npx nightward --version
-npm install -g nightward
+npm view @jsonbored/nightward version dist.integrity repository
+npm view @jsonbored/nightward --json | jq '.dist'
+npx @jsonbored/nightward --version
+npm install -g @jsonbored/nightward
 nw doctor --json
 ```
 

--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -1,12 +1,12 @@
-# nightward
+# @jsonbored/nightward
 
 NPM launcher for Nightward.
 
 Nightward is a local-first TUI/CLI for auditing AI agent state, MCP config, and dotfiles backup safety.
 
 ```sh
-npx nightward --help
-npm install -g nightward
+npx @jsonbored/nightward --help
+npm install -g @jsonbored/nightward
 nw scan --json
 ```
 

--- a/packages/npm/package-lock.json
+++ b/packages/npm/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nightward",
+  "name": "@jsonbored/nightward",
   "version": "0.0.0-development",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "nightward",
+      "name": "@jsonbored/nightward",
       "version": "0.0.0-development",
       "license": "MIT",
       "bin": {

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nightward",
+  "name": "@jsonbored/nightward",
   "version": "0.0.0-development",
   "description": "Local-first TUI/CLI for auditing AI agent state, MCP config, and dotfiles backup safety.",
   "license": "MIT",

--- a/scripts/verify-npm-release.sh
+++ b/scripts/verify-npm-release.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 version="${1:?package version required, for example 0.1.0}"
-package="${NPM_PACKAGE:-nightward}"
+package="${NPM_PACKAGE:-@jsonbored/nightward}"
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "${tmp_dir}"' EXIT
 

--- a/site/guide/install.md
+++ b/site/guide/install.md
@@ -25,8 +25,8 @@ After the first tagged release:
 The npm package is a launcher, not a JavaScript rewrite:
 
 ```sh
-npx nightward --help
-npm install -g nightward
+npx @jsonbored/nightward --help
+npm install -g @jsonbored/nightward
 nw scan --json
 ```
 

--- a/site/index.md
+++ b/site/index.md
@@ -28,7 +28,7 @@ features:
 <!-- markdownlint-disable MD041 -->
 
 ```sh
-npx nightward --help
+npx @jsonbored/nightward --help
 nw doctor --json
 nw scan --workspace . --json
 nw policy sarif --workspace . --include-analysis --output nightward.sarif

--- a/site/security/release-verification.md
+++ b/site/security/release-verification.md
@@ -26,7 +26,7 @@ The npm package downloads the matching GitHub Release archive on first run and v
 After install:
 
 ```sh
-npx nightward --version
+npx @jsonbored/nightward --version
 nw doctor --json
 ```
 


### PR DESCRIPTION
## Summary
- switch the npm launcher package to `@jsonbored/nightward` after npm rejected the unscoped `nightward` name
- keep the installed binaries as `nightward` and `nw`
- update README, docs, site install guidance, and npm release verification defaults

## What changed
- updated `packages/npm/package.json` and lockfile package identity
- updated public install commands to `npx @jsonbored/nightward` and `npm install -g @jsonbored/nightward`
- updated release docs and `scripts/verify-npm-release.sh` to verify the scoped package

## Why
- npm blocks the unscoped `nightward` package name as too similar to an existing package, so the publishable package must be scoped while preserving the CLI binary names.

## Validation
- `make verify`
- `make release-snapshot`
- `git diff --check`
- `renovate-config-validator renovate.json`
- `npm audit --audit-level=moderate` in `packages/npm`, `integrations/raycast`, and `site`
- `npm trust list @jsonbored/nightward`
- `npm view @jsonbored/nightward@0.0.0-bootstrap.0 deprecated version dist-tags`

## Notes
- published `@jsonbored/nightward@0.0.0-bootstrap.0` under the bootstrap tag to create the package
- configured npm trusted publishing for `JSONbored/nightward`, workflow `release.yml`, environment `npm-publish`
- deprecated the bootstrap version; first real release will replace the `latest` dist-tag with `v0.1.0`
