### PR TITLE
ci(release): install syft before goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,12 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 
+      - name: Install Syft
+        run: |
+          set -euo pipefail
+          go install github.com/anchore/syft/cmd/syft@v1.43.0
+          echo "$(go env GOPATH)/bin" >> "${GITHUB_PATH}"
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
         with:


### PR DESCRIPTION
## Summary
- install Syft in the real release workflow before GoReleaser runs
- add GOPATH/bin to `GITHUB_PATH` so GoReleaser can catalog SBOMs during release

## What changed
- mirrors the already-passing `make release-snapshot` prerequisite in `.github/workflows/release.yml`

## Why
- the first `v0.1.0` release run failed because GoReleaser could not find `syft` while cataloging artifacts

## Validation
- `git diff --check`
- `bash scripts/test-release-scripts.sh`
- `actionlint .github/workflows/release.yml`

## Notes
- after this merges, the failed `v0.1.0` tag must be replaced so the release workflow runs from a commit containing this fix
