### PR TITLE
ci(release): keep cosign checksum outputs compatible

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -62,6 +62,7 @@ signs:
     args:
       - sign-blob
       - --yes
+      - --new-bundle-format=false
       - --output-signature=${signature}
       - --output-certificate=${certificate}
       - ${artifact}


### PR DESCRIPTION
## Summary
- force Cosign to use the legacy separate signature/certificate output format for checksum signing

## What changed
- adds `--new-bundle-format=false` to the GoReleaser `cosign sign-blob` args

## Why
- the `v0.1.0` release got through Syft cataloging but failed because Cosign v3 ignored `--output-signature` under the new bundle format and then tried to create a bundle at an empty path
- Nightward release verification docs and scripts currently expect `checksums.txt.sig` and `checksums.txt.pem`

## Validation
- `git diff --check`
- `go run github.com/goreleaser/goreleaser/v2@v2.9.0 check`
- `go run github.com/sigstore/cosign/v3/cmd/cosign@v3.0.2 sign-blob --help` confirmed `--new-bundle-format`, `--output-signature`, and `--output-certificate` support

## Notes
- after this merges, the failed `v0.1.0` tag must be replaced again so the release workflow runs from the fixed commit
