### PR TITLE
ci(release): disable cosign signing config for legacy checksum artifacts

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -62,6 +62,7 @@ signs:
     args:
       - sign-blob
       - --yes
+      - --use-signing-config=false
       - --new-bundle-format=false
       - --output-signature=${signature}
       - --output-certificate=${certificate}

--- a/docs/release.md
+++ b/docs/release.md
@@ -45,6 +45,7 @@ Verify a release locally with:
 
 ```sh
 cosign verify-blob \
+  --new-bundle-format=false \
   --certificate-identity-regexp 'https://github.com/JSONbored/nightward/.github/workflows/release.yml@refs/tags/v.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate checksums.txt.pem \

--- a/scripts/smoke-release-archive.sh
+++ b/scripts/smoke-release-archive.sh
@@ -24,6 +24,7 @@ gh release download "${tag}" \
 cd "${tmp_dir}"
 test -s "${asset}.sbom.json"
 cosign verify-blob \
+  --new-bundle-format=false \
   --certificate-identity-regexp "https://github.com/${repo}/.github/workflows/release.yml@refs/tags/v.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate checksums.txt.pem \


### PR DESCRIPTION
## Summary
- keep release checksum signing on the documented `.sig` and `.pem` artifacts with Cosign v3
- make release smoke verification opt out of bundle-mode verification for those legacy artifacts
- update release verification docs to match the smoke script

## What changed
- add `--use-signing-config=false` to GoReleaser Cosign signing args
- add `--new-bundle-format=false` to the release smoke verifier
- document the matching local `cosign verify-blob` command

## Why
Cosign v3 enables TUF signing-config behavior by default and rejects the legacy output mode unless it is explicitly disabled. Nightward still publishes `checksums.txt.sig` and `checksums.txt.pem`, so the release workflow and verification command need to opt into that compatibility mode.

## Validation
- `git diff --check`
- `go run github.com/goreleaser/goreleaser/v2@v2.9.0 check`
- `bash scripts/test-release-scripts.sh`
- `go run github.com/sigstore/cosign/v3/cmd/cosign@v3.0.2 sign-blob --help | rg -n "use-signing-config|new-bundle-format|output-signature|output-certificate" -C 1`
- `go run github.com/sigstore/cosign/v3/cmd/cosign@v3.0.2 verify-blob --help | rg -n "new-bundle-format|certificate-identity|signature" -C 1`
- `make release-snapshot`

## Notes
- This preserves the existing public artifact names instead of switching release verification to bundle-only artifacts during `v0.1.0`.