### PR TITLE
ci(release): use cosign bundle signatures for checksums

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,14 +59,12 @@ sboms:
 signs:
   - cmd: cosign
     artifacts: checksum
+    signature: "${artifact}.sigstore.json"
     args:
       - sign-blob
-      - --yes
-      - --use-signing-config=false
-      - --new-bundle-format=false
-      - --output-signature=${signature}
-      - --output-certificate=${certificate}
+      - --bundle=${signature}
       - ${artifact}
+      - --yes
 
 changelog:
   use: github

--- a/docs/install.md
+++ b/docs/install.md
@@ -18,8 +18,7 @@ Release artifacts include:
 
 - `nightward` and `nw` binaries for macOS, Linux, and Windows.
 - `checksums.txt`.
-- `checksums.txt.sig` from Cosign.
-- `checksums.txt.pem` from Cosign keyless signing.
+- `checksums.txt.sigstore.json` from Cosign keyless signing.
 - SBOM files for release archives.
 
 Users who want the strongest supply-chain verification should download from GitHub Releases and verify the signed checksum file before installing.

--- a/docs/release.md
+++ b/docs/release.md
@@ -45,11 +45,7 @@ Verify a release locally with:
 
 ```sh
 cosign verify-blob \
-  --new-bundle-format=false \
-  --certificate-identity-regexp 'https://github.com/JSONbored/nightward/.github/workflows/release.yml@refs/tags/v.*' \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate checksums.txt.pem \
-  --signature checksums.txt.sig \
+  --bundle checksums.txt.sigstore.json \
   checksums.txt
 ```
 

--- a/scripts/smoke-release-archive.sh
+++ b/scripts/smoke-release-archive.sh
@@ -15,8 +15,7 @@ trap 'rm -rf "${tmp_dir}"' EXIT
 gh release download "${tag}" \
   --repo "${repo}" \
   --pattern checksums.txt \
-  --pattern checksums.txt.pem \
-  --pattern checksums.txt.sig \
+  --pattern checksums.txt.sigstore.json \
   --pattern "${asset}" \
   --pattern "${asset}.sbom.json" \
   --dir "${tmp_dir}"
@@ -24,11 +23,7 @@ gh release download "${tag}" \
 cd "${tmp_dir}"
 test -s "${asset}.sbom.json"
 cosign verify-blob \
-  --new-bundle-format=false \
-  --certificate-identity-regexp "https://github.com/${repo}/.github/workflows/release.yml@refs/tags/v.*" \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate checksums.txt.pem \
-  --signature checksums.txt.sig \
+  --bundle checksums.txt.sigstore.json \
   checksums.txt
 sha256sum -c checksums.txt --ignore-missing
 tar -xzf "${asset}"


### PR DESCRIPTION
## Summary
- switch checksum signing to Cosign v3 bundle artifacts
- smoke the published release with `checksums.txt.sigstore.json`
- update release/install docs to match the artifact users should verify

## What changed
- configure GoReleaser to produce `checksums.txt.sigstore.json`
- download and verify the bundle in `scripts/smoke-release-archive.sh`
- replace `.sig`/`.pem` verification docs with the bundle command

## Why
Cosign v3 and GoReleaser now recommend bundle-based blob signing. The previous compatibility attempt produced `checksums.txt.sig` but no certificate asset, so the release smoke correctly failed.

## Validation
- `git diff --check`
- `go run github.com/goreleaser/goreleaser/v2@v2.9.0 check`
- `bash scripts/test-release-scripts.sh`
- `go run github.com/sigstore/cosign/v3/cmd/cosign@v3.0.2 verify-blob --help | rg -n -C 1 -- "--bundle|new-bundle-format"`
- `make release-snapshot`

## Notes
- The existing partial `v0.1.0` GitHub Release should be deleted before rerunning the corrected release tag so stale `.sig` assets are not retained.