### PR TITLE
ci(release): verify cosign keyless checksum bundles

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -46,6 +46,8 @@ Verify a release locally with:
 ```sh
 cosign verify-blob \
   --bundle checksums.txt.sigstore.json \
+  --certificate-identity-regexp 'https://github.com/JSONbored/nightward/.github/workflows/release.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   checksums.txt
 ```
 

--- a/scripts/smoke-release-archive.sh
+++ b/scripts/smoke-release-archive.sh
@@ -24,6 +24,8 @@ cd "${tmp_dir}"
 test -s "${asset}.sbom.json"
 cosign verify-blob \
   --bundle checksums.txt.sigstore.json \
+  --certificate-identity-regexp "https://github.com/${repo}/.github/workflows/release.yml@refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+$" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   checksums.txt
 sha256sum -c checksums.txt --ignore-missing
 tar -xzf "${asset}"


### PR DESCRIPTION
## Summary
- add the expected GitHub Actions OIDC identity and issuer to release checksum bundle verification
- document the same Cosign verification command for local release checks

## What changed
- `scripts/smoke-release-archive.sh` now verifies `checksums.txt.sigstore.json` with the release workflow identity regex and GitHub Actions issuer
- `docs/release.md` mirrors the required Cosign v3 keyless verification flags

## Why
- Cosign v3 requires an explicit keyless certificate identity or identity regex when verifying a bundle
- the `v0.1.1` release assets are present and signed, but the release smoke job failed before npm could publish because the verifier command was incomplete

## Validation
- `bash -n scripts/smoke-release-archive.sh`
- `git diff --check`
- `bash scripts/test-release-scripts.sh`
- `go run github.com/sigstore/cosign/v3/cmd/cosign@v3.0.2 verify-blob --bundle checksums.txt.sigstore.json --certificate-identity-regexp 'https://github.com/JSONbored/nightward/.github/workflows/release.yml@refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+$' --certificate-oidc-issuer https://token.actions.githubusercontent.com checksums.txt` against the downloaded `v0.1.1` checksum bundle
- `make release-snapshot`

## Notes
- After merge, cut a new signed patch tag because the failed `v0.1.1` release workflow cannot be rerun with this workflow-script fix.