### PR TITLE
fix(release): inject tag version into binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,8 @@ builds:
     binary: nightward
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X github.com/jsonbored/nightward/internal/cli.version={{ .Version }}
     goos:
       - darwin
       - linux
@@ -24,6 +26,8 @@ builds:
     binary: nw
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X github.com/jsonbored/nightward/internal/cli.version={{ .Version }}
     goos:
       - darwin
       - linux

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -23,7 +23,7 @@ import (
 	"github.com/jsonbored/nightward/internal/tui"
 )
 
-const version = "0.1.0"
+var version = "0.1.0"
 
 type Check struct {
 	ID      string `json:"id"`


### PR DESCRIPTION
## Summary
- make the CLI version variable linker-overridable
- inject GoReleaser `.Version` into both `nightward` and `nw` binaries

## What changed
- changed `internal/cli.version` from a constant to a variable so `-X` can override it
- added matching GoReleaser ldflags for both released binaries

## Why
- the release smoke correctly caught that immutable `v0.1.2` binaries still reported `0.1.0`
- npm publishing depends on the release archive smoke passing first

## Validation
- `go test ./internal/cli`
- `go run -ldflags '-X github.com/jsonbored/nightward/internal/cli.version=9.8.7-test' ./cmd/nightward --version`
- `go run -ldflags '-X github.com/jsonbored/nightward/internal/cli.version=9.8.7-test' ./cmd/nw --version`
- `go run github.com/goreleaser/goreleaser/v2@v2.9.0 check`
- `git diff --check`
- `make release-snapshot`
- extracted `dist/nightward_0.1.2-SNAPSHOT-76b8a3c_darwin_arm64.tar.gz` and verified both binaries print `0.1.2-SNAPSHOT-76b8a3c`

## Notes
- After merge, cut a new signed patch tag because the immutable `v0.1.2` release already exists with binaries that report `0.1.0`.