### PR TITLE
fix(release): harden install version smokes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,8 +121,16 @@ jobs:
           tmp_prefix="$(mktemp -d)"
           trap 'rm -rf "${tmp_prefix}"' EXIT
           npm install --global --prefix "${tmp_prefix}" "./${package_tarball}"
-          PATH="${tmp_prefix}/bin:${PATH}" nightward --version
-          PATH="${tmp_prefix}/bin:${PATH}" nw --version
+          nightward_version="$(PATH="${tmp_prefix}/bin:${PATH}" nightward --version)"
+          if [[ "${nightward_version}" != "${version}" ]]; then
+            echo "nightward --version returned ${nightward_version}, expected ${version}" >&2
+            exit 1
+          fi
+          nw_version="$(PATH="${tmp_prefix}/bin:${PATH}" nw --version)"
+          if [[ "${nw_version}" != "${version}" ]]; then
+            echo "nw --version returned ${nw_version}, expected ${version}" >&2
+            exit 1
+          fi
 
       - name: Publish npm package
         run: npm publish --access public --provenance

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -23,7 +24,7 @@ import (
 	"github.com/jsonbored/nightward/internal/tui"
 )
 
-var version = "0.1.0"
+var version = "devel"
 
 type Check struct {
 	ID      string `json:"id"`
@@ -71,7 +72,7 @@ func RunWithName(commandName string, args []string, stdout, stderr io.Writer) in
 	case "-h", "--help", "help":
 		printHelp(stdout, commandName)
 	case "--version", "version":
-		fmt.Fprintln(stdout, version)
+		fmt.Fprintln(stdout, currentVersion())
 	case "scan":
 		return runScan(home, args[1:], stdout, stderr)
 	case "doctor":
@@ -826,13 +827,26 @@ func doctor(home string) DoctorReport {
 	}
 	return DoctorReport{
 		GeneratedAt: time.Now().UTC(),
-		Version:     version,
+		Version:     currentVersion(),
 		Home:        home,
 		Executable:  exe,
 		Checks:      checks,
 		Schedule:    schedule.Status(home),
 		Adapters:    report.Adapters,
 	}
+}
+
+func currentVersion() string {
+	if v := strings.TrimSpace(version); v != "" && v != "devel" {
+		return v
+	}
+	if info, ok := debug.ReadBuildInfo(); ok {
+		moduleVersion := strings.TrimSpace(info.Main.Version)
+		if moduleVersion != "" && moduleVersion != "(devel)" {
+			return strings.TrimPrefix(moduleVersion, "v")
+		}
+	}
+	return "devel"
 }
 
 func commandCheck(name, detail string) Check {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -223,6 +223,15 @@ func TestHelpVersionAndCommandErrors(t *testing.T) {
 
 	stdout.Reset()
 	stderr.Reset()
+	oldVersion := version
+	version = "9.8.7-test"
+	t.Cleanup(func() { version = oldVersion })
+	if code := RunWithName("nightward", []string{"--version"}, &stdout, &stderr); code != 0 || strings.TrimSpace(stdout.String()) != "9.8.7-test" {
+		t.Fatalf("version override failed: code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
 	if code := RunWithName("nw", []string{"providers", "bogus"}, &stdout, &stderr); code == 0 || !strings.Contains(stderr.String(), "usage: nightward providers") {
 		t.Fatalf("expected providers error, code=%d stderr=%q", code, stderr.String())
 	}

--- a/packages/npm/bin/nightward.mjs
+++ b/packages/npm/bin/nightward.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
-import { createWriteStream, existsSync } from "node:fs";
+import { createWriteStream, existsSync, realpathSync } from "node:fs";
 import { chmod, mkdir, readFile, rm } from "node:fs/promises";
 import { get } from "node:https";
 import { homedir, platform as osPlatform, tmpdir } from "node:os";
@@ -183,21 +183,31 @@ export async function ensureBinary(command = commandName()) {
 async function main() {
   const command = commandName();
   const binary = await ensureBinary(command);
-  const child = spawn(binary, process.argv.slice(2), { stdio: "inherit" });
-  child.on("exit", (code, signal) => {
-    if (signal) {
-      process.kill(process.pid, signal);
-      return;
-    }
-    process.exit(code ?? 1);
+  const result = await new Promise((resolve, reject) => {
+    const child = spawn(binary, process.argv.slice(2), { stdio: "inherit" });
+    child.on("error", reject);
+    child.on("exit", (code, signal) => resolve({ code: code ?? 1, signal }));
   });
-  child.on("error", (error) => {
-    console.error(`nightward launcher failed: ${error.message}`);
-    process.exit(1);
-  });
+
+  if (result.signal) {
+    process.kill(process.pid, result.signal);
+    return;
+  }
+  process.exit(result.code);
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
+function isMainModule() {
+  if (!process.argv[1]) {
+    return false;
+  }
+  try {
+    return realpathSync(modulePath) === realpathSync(process.argv[1]);
+  } catch {
+    return import.meta.url === pathToFileURL(process.argv[1]).href;
+  }
+}
+
+if (isMainModule()) {
   main().catch((error) => {
     console.error(`nightward launcher failed: ${error.message}`);
     process.exit(1);

--- a/packages/npm/test/launcher.test.mjs
+++ b/packages/npm/test/launcher.test.mjs
@@ -1,6 +1,8 @@
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
 import assert from "node:assert/strict";
 
@@ -57,4 +59,29 @@ test("uses invocation name and environment overrides", () => {
     delete process.env.NIGHTWARD_NPM_CACHE;
     delete process.env.NIGHTWARD_NPM_DOWNLOAD_BASE;
   }
+});
+
+test("runs through npm bin symlink and waits for child output", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "nightward-npm-bin-"));
+  const fakeBinary = path.join(dir, "fake-nightward.mjs");
+  const launcherLink = path.join(dir, "nightward");
+  const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+  await writeFile(fakeBinary, `#!/usr/bin/env node
+console.log("fake-nightward " + process.argv.slice(2).join(" "));
+`, "utf8");
+  await chmod(fakeBinary, 0o755);
+  await symlink(path.join(packageRoot, "bin/nightward.mjs"), launcherLink);
+
+  const result = spawnSync(process.execPath, [launcherLink, "--version"], {
+    cwd: packageRoot,
+    env: {
+      ...process.env,
+      NIGHTWARD_BIN: fakeBinary
+    },
+    encoding: "utf8"
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "fake-nightward --version");
 });


### PR DESCRIPTION
## Summary
- fix npm launcher execution when invoked through npm bin symlinks
- make source-built CLI versions use Go build info instead of a stale release fallback
- require release npm install smokes to assert exact command output

## What changed
- npm launcher resolves symlinked entrypoints and awaits the child binary before exiting
- CLI defaults to `devel` locally while GoReleaser can still inject the release tag
- release workflow fails if `nightward --version` or `nw --version` does not equal the tag version
- added regression coverage for npm bin symlink execution and CLI version override

## Why
- v0.1.3 proved GitHub/npm publishing works, but install smokes could miss empty launcher output and stale source-install versions

## Validation
- `go test ./internal/cli`
- `npm test --prefix packages/npm`
- `go run ./cmd/nightward --version`
- `go run -ldflags '-X github.com/jsonbored/nightward/internal/cli.version=9.8.7-test' ./cmd/nightward --version`\n- `go run -ldflags '-X github.com/jsonbored/nightward/internal/cli.version=9.8.7-test' ./cmd/nw --version`\n- `npm audit --audit-level=moderate --prefix packages/npm`\n- `npm audit --audit-level=moderate --prefix integrations/raycast`\n- `make release-snapshot`\n- extracted snapshot archive: `nightward --version` and `nw --version` matched snapshot version\n- `make verify`\n\n## Notes\n- This is release-process hardening only; no runtime scanning behavior changes.