### PR TITLE
feat(raycast): add menu bar status and local test suites

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
+# Nightward is currently single-maintainer. Keep ownership explicit so branch
+# protection can require CODEOWNERS review as additional maintainers are added.
 * @JSONbored

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,8 @@ jobs:
       - name: Gosec static analysis
         run: make gosec
 
-      - name: Fuzz smoke
-        run: make fuzz-smoke
+      - name: Fuzz test
+        run: make fuzz-test
 
       - name: Coverage gate
         run: make coverage-check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,11 @@ jobs:
           npm pack --dry-run
           tmp_prefix="$(mktemp -d)"
           trap 'rm -rf "${tmp_prefix}"' EXIT
-          npm install --global --prefix "${tmp_prefix}" "./${package_tarball}"
+          tar -xzf "${package_tarball}" -C "${tmp_prefix}"
+          chmod 0755 "${tmp_prefix}/package/bin/nightward.mjs"
+          mkdir -p "${tmp_prefix}/bin"
+          ln -s "${tmp_prefix}/package/bin/nightward.mjs" "${tmp_prefix}/bin/nightward"
+          ln -s "${tmp_prefix}/package/bin/nightward.mjs" "${tmp_prefix}/bin/nw"
           nightward_version="$(PATH="${tmp_prefix}/bin:${PATH}" nightward --version)"
           if [[ "${nightward_version}" != "${version}" ]]; then
             echo "nightward --version returned ${nightward_version}, expected ${version}" >&2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,16 @@ Nightward should stay useful to AI power users without becoming a tool that copi
 ## Development
 
 ```sh
+make test-fast
+make test-security
+make test-ux
+make test-release
+make test-prepush
+```
+
+`make test-prepush` is the full local gate and should pass before pushing release-sensitive branches. The lower-level commands below remain useful for focused iteration:
+
+```sh
 make test
 make test-junit
 make trunk-flaky-validate

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,26 @@ SITE_DIR ?= site
 GO_PACKAGES ?= $(shell go list ./cmd/... ./internal/... ./tools/...)
 COVERAGE_PACKAGES ?= ./internal/...
 
-.PHONY: test test-race vet staticcheck gosec gitleaks govulncheck fuzz-smoke coverage coverage-check go-test-junit test-junit trunk-check trunk-fix trunk-flaky-validate ci-scripts-test raycast-install raycast-test raycast-test-junit raycast-audit raycast-lint raycast-build raycast-verify npm-package-install npm-package-test npm-package-audit npm-package-pack npm-package-verify site-install site-audit site-build site-verify demo-assets tool-syft release-snapshot verify build install-local clean-reports
+.PHONY: test test-fast test-security test-ux test-release test-local test-prepush test-release-install test-race vet staticcheck gosec gitleaks govulncheck fuzz-smoke fuzz-test coverage coverage-check go-test-junit test-junit trunk-check trunk-fix trunk-flaky-validate ci-scripts-test raycast-install raycast-test raycast-test-junit raycast-audit raycast-lint raycast-build raycast-verify npm-package-install npm-package-test npm-package-audit npm-package-pack npm-package-verify site-install site-audit site-build site-verify demo-assets tool-syft release-snapshot verify build install-local clean-reports
 
 test:
 	go test $(GO_PACKAGES)
+
+test-fast: test npm-package-test raycast-test
+
+test-security: vet staticcheck gosec gitleaks govulncheck npm-package-audit raycast-audit site-audit
+
+test-ux: raycast-verify site-verify
+
+test-release: ci-scripts-test npm-package-verify raycast-build site-build release-snapshot
+
+test-local: verify
+
+test-prepush: verify
+
+test-release-install:
+	@if [ -z "$${VERSION:-}" ]; then echo "VERSION is required, for example: make test-release-install VERSION=0.1.4" >&2; exit 2; fi
+	bash scripts/verify-npm-release.sh "$${VERSION}"
 
 test-race:
 	go test -race $(GO_PACKAGES)
@@ -39,6 +55,8 @@ govulncheck:
 
 fuzz-smoke:
 	go test ./internal/inventory -run=^$$ -fuzz=FuzzMCPConfigParsing -fuzztime=10s
+
+fuzz-test: fuzz-smoke
 
 coverage:
 	mkdir -p $(REPORTS_DIR)

--- a/docs/ci-security.md
+++ b/docs/ci-security.md
@@ -25,6 +25,7 @@ Nightward's CI is meant to prove the project is serious about the same safety po
 - Never make flaky-test quarantining a default CI behavior.
 - Use Renovate instead of Dependabot whenever possible.
 - Keep dependency PRs reviewed; do not enable broad automerge by default.
+- `main` branch protection requires two approving reviews and CODEOWNERS review. While Nightward has only one maintainer, maintainer merges require an explicit admin bypass and an issue/PR note explaining why normal review could not be satisfied.
 - Use repo-controlled `make gitleaks` and `make govulncheck` targets in CI so local and remote behavior match.
 - Install Trunk in CI from a pinned release archive with a checked SHA-256 instead of a moving launcher URL.
 - Keep Trunk Flaky Tests secrets scoped to the detection/upload steps only.
@@ -51,3 +52,17 @@ trunk check enable nightward-policy
 
 - Add SLSA provenance/attestations once release artifact flow is stable.
 - Defer Homebrew tap automation until the first tagged release.
+
+## Local Test Suites
+
+Use suite aliases before pushing:
+
+```sh
+make test-fast
+make test-security
+make test-ux
+make test-release
+make test-prepush
+```
+
+`make test-prepush` is the full local release gate. It should pass before pushing a release-sensitive branch.

--- a/docs/raycast-extension.md
+++ b/docs/raycast-extension.md
@@ -11,6 +11,7 @@ integrations/raycast
 ## Commands
 
 - `Nightward Dashboard`: scan counts, schedule status, adapter summary, and top findings.
+- `Nightward Status`: menu-bar counter for finding severity, analysis signals, provider warnings, and scheduled-report state.
 - `Nightward Findings`: searchable findings with a severity filter, detail pane, and copy/open-doc actions.
 - `Nightward Analysis`: offline analysis signals with severity, confidence, evidence, and recommended action.
 - `Nightward Provider Doctor`: optional provider availability and privacy posture.
@@ -41,6 +42,8 @@ The extension uses `execFile`, not a shell, for local Nightward commands. It cal
 
 It does not call schedule install/remove, backup writes, snapshot writes, restore, Git, or any config mutation command.
 
+The menu-bar command runs the same read-only scan, doctor, and offline analysis commands. It does not enable online providers or background mutation.
+
 ## Validation
 
 ```sh
@@ -60,6 +63,7 @@ npm run dev
 Manual smoke must use a fixture `Home Override`, not a real local home, before screenshots or store metadata are published. Cover at least:
 
 - Dashboard loads scan counts, schedule status, adapters, and top findings.
+- Menu-bar status shows finding, analysis, provider-warning, and schedule counters; its actions open existing read-only commands and copy a redacted summary.
 - Findings search/filter/detail panes render redacted evidence and docs actions.
 - Analysis renders offline signals and provider warnings.
 - Provider Doctor shows local provider status and does not run online-capable providers without explicit opt-in.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,6 +4,30 @@ Nightward treats read-only behavior, redaction, and policy stability as release 
 
 ## Local Checks
 
+Use the suite aliases first. They are intentionally shaped around the same surfaces CI and release workflows gate, so local failures are caught before a branch is pushed.
+
+```sh
+make test-fast
+make test-security
+make test-ux
+make test-release
+make test-prepush
+```
+
+- `make test-fast` runs Go unit tests plus npm launcher and Raycast unit tests.
+- `make test-security` runs static analysis, secret/vulnerability checks, and npm audits.
+- `make test-ux` runs the Raycast and VitePress site validation paths.
+- `make test-release` runs release helper tests, npm package verification, Raycast/site builds, and a GoReleaser snapshot.
+- `make test-prepush` is the full local gate and is equivalent to `make verify`.
+
+After a package is published, verify the install path explicitly:
+
+```sh
+make test-release-install VERSION=0.1.4
+```
+
+The lower-level targets remain available for focused iteration:
+
 ```sh
 make test
 make test-race
@@ -45,7 +69,7 @@ make verify
 - TUI model tests cover tab switching, search, filters, help, cursor clamping, dashboard report history, what-next guidance, wide detail panes, compact terminal rendering, and redaction.
 - Scheduler tests cover report history ordering, finding counts, non-report filtering, and symlink skipping without installing timers.
 - Raycast extension tests cover pure redaction/formatting helpers and safe command execution wrappers.
-- `go vet`, `staticcheck`, `gosec`, `gitleaks`, `govulncheck`, and fuzz smoke tests are part of the local verification bar. `#nosec` comments must include a narrow reason tied to an intentional local CLI behavior.
+- `go vet`, `staticcheck`, `gosec`, `gitleaks`, `govulncheck`, and fuzz tests are part of the local verification bar. `#nosec` comments must include a narrow reason tied to an intentional local CLI behavior.
 - `make coverage-check` enforces at least 83% combined statement coverage for `./internal/...`.
 - `make ci-scripts-test` verifies repository-maintained CI helper scripts such as DCO checking, action path validation, and release-script input validation.
 - Raycast dependency audits run with `npm audit --audit-level=moderate`.
@@ -82,7 +106,7 @@ npm run lint
 npm run build
 ```
 
-`npm run dev` is the manual smoke path when the Raycast CLI is available. Do not run `npm run publish` unless release/publish scope is explicit.
+`npm run dev` is the manual Raycast development path when the Raycast CLI is available. Do not run `npm run publish` unless release/publish scope is explicit.
 
 Manual smoke and screenshots must use fixture `Home Override` data only. Keep the evidence table in `docs/screenshots.md` current before broader promotion or Raycast store metadata work.
 

--- a/integrations/raycast/CHANGELOG.md
+++ b/integrations/raycast/CHANGELOG.md
@@ -3,4 +3,5 @@
 ## 0.1.0
 
 - Add read-only Dashboard, Findings, Explain Finding, Export Fix Plan, and Open Reports commands.
+- Add a read-only menu-bar status command for finding, analysis, provider-warning, and scheduled-report counters.
 - Shell out with `execFile` and render only redacted Nightward JSON/Markdown output.

--- a/integrations/raycast/README.md
+++ b/integrations/raycast/README.md
@@ -7,9 +7,14 @@ This extension is read-only. It runs local `nw`/`nightward` commands, renders re
 ## Commands
 
 - `Nightward Dashboard`: scan summary, schedule status, adapters, and top findings.
+- `Nightward Status`: menu-bar counter for findings, analysis signals, provider warnings, and scheduled-report state.
 - `Nightward Findings`: searchable findings with severity filters and detail panes.
+- `Nightward Analysis`: offline analysis signals and provider warnings.
+- `Nightward Provider Doctor`: optional provider status without executing online providers.
 - `Explain Nightward Finding`: detail view for a specific finding ID.
+- `Explain Nightward Signal`: detail view for the analysis signal attached to a finding ID.
 - `Export Nightward Fix Plan`: copies `nw fix export --format markdown` output.
+- `Export Nightward Analysis`: copies redacted offline analysis markdown.
 - `Open Nightward Reports`: opens `~/.local/state/nightward/reports` in Finder.
 
 ## Preferences

--- a/integrations/raycast/package.json
+++ b/integrations/raycast/package.json
@@ -38,6 +38,13 @@
       "keywords": ["nightward", "nw", "scan", "doctor", "security"]
     },
     {
+      "name": "status-menu",
+      "title": "Nightward Status",
+      "description": "Show Nightward finding, analysis, and schedule counters in the menu bar.",
+      "mode": "menu-bar",
+      "keywords": ["nightward", "status", "monitor", "security", "findings"]
+    },
+    {
       "name": "findings",
       "title": "Nightward Findings",
       "description": "Browse redacted Nightward findings with severity filters and fix guidance.",

--- a/integrations/raycast/raycast-env.d.ts
+++ b/integrations/raycast/raycast-env.d.ts
@@ -20,6 +20,8 @@ declare type Preferences = ExtensionPreferences
 declare namespace Preferences {
   /** Preferences accessible in the `dashboard` command */
   export type Dashboard = ExtensionPreferences & {}
+  /** Preferences accessible in the `status-menu` command */
+  export type StatusMenu = ExtensionPreferences & {}
   /** Preferences accessible in the `findings` command */
   export type Findings = ExtensionPreferences & {}
   /** Preferences accessible in the `analysis` command */
@@ -41,6 +43,8 @@ declare namespace Preferences {
 declare namespace Arguments {
   /** Arguments passed to the `dashboard` command */
   export type Dashboard = {}
+  /** Arguments passed to the `status-menu` command */
+  export type StatusMenu = {}
   /** Arguments passed to the `findings` command */
   export type Findings = {}
   /** Arguments passed to the `analysis` command */

--- a/integrations/raycast/src/format.ts
+++ b/integrations/raycast/src/format.ts
@@ -3,6 +3,7 @@ import type {
   AnalysisReport,
   AnalysisSignal,
   Classification,
+  DoctorReport,
   Finding,
   FixPlan,
   RiskLevel,
@@ -250,6 +251,86 @@ export function adapterSummary(adapters: AdapterStatus[]): string {
 
 export function fixPlanSummary(plan: FixPlan): string {
   return `Safe ${plan.summary.safe} - Review ${plan.summary.review} - Blocked ${plan.summary.blocked}`;
+}
+
+export type MenuBarStatus = {
+  title: string;
+  tooltip: string;
+  risk: RiskLevel;
+  findings: number;
+  critical: number;
+  high: number;
+  medium: number;
+  signals: number;
+  providerWarnings: number;
+  scheduled: boolean;
+  lastFindings?: number;
+  lastReport?: string;
+};
+
+export function menuBarStatus(
+  report: ScanReport,
+  doctor: DoctorReport,
+  analysis: AnalysisReport,
+): MenuBarStatus {
+  const risk = maxSeverity(report.findings);
+  const critical = report.summary.findings_by_severity.critical ?? 0;
+  const high = report.summary.findings_by_severity.high ?? 0;
+  const medium = report.summary.findings_by_severity.medium ?? 0;
+  const findings = report.summary.total_findings;
+  const signals = analysis.summary.total_signals;
+  const providerWarnings = analysis.summary.provider_warnings;
+  const issueCount = findings + providerWarnings;
+  const title =
+    issueCount === 0
+      ? "NW OK"
+      : critical > 0
+        ? `NW ${critical}C`
+        : high > 0
+          ? `NW ${high}H`
+          : `NW ${issueCount}`;
+  const tooltip = [
+    `${findings} findings`,
+    `${signals} analysis signals`,
+    `${providerWarnings} provider warnings`,
+    `max risk: ${risk}`,
+    doctor.schedule.installed ? "scheduled" : "not scheduled",
+  ].join(" - ");
+
+  return {
+    title,
+    tooltip,
+    risk,
+    findings,
+    critical,
+    high,
+    medium,
+    signals,
+    providerWarnings,
+    scheduled: doctor.schedule.installed,
+    lastFindings: doctor.schedule.last_findings,
+    lastReport: doctor.schedule.last_report,
+  };
+}
+
+export function menuBarStatusMarkdown(status: MenuBarStatus): string {
+  return [
+    "# Nightward Status",
+    "",
+    `Findings: \`${status.findings}\``,
+    `Critical: \`${status.critical}\``,
+    `High: \`${status.high}\``,
+    `Medium: \`${status.medium}\``,
+    `Analysis signals: \`${status.signals}\``,
+    `Provider warnings: \`${status.providerWarnings}\``,
+    `Scheduled: \`${status.scheduled ? "yes" : "no"}\``,
+    status.lastFindings !== undefined
+      ? `Last scheduled findings: \`${status.lastFindings}\``
+      : "",
+    status.lastReport ? `Last report: \`${status.lastReport}\`` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
 }
 
 export function basename(path: string): string {

--- a/integrations/raycast/src/status-menu.tsx
+++ b/integrations/raycast/src/status-menu.tsx
@@ -1,0 +1,193 @@
+import {
+  Clipboard,
+  Color,
+  Icon,
+  LaunchType,
+  MenuBarExtra,
+  getPreferenceValues,
+  launchCommand,
+  open,
+  showHUD,
+} from "@raycast/api";
+import { usePromise } from "@raycast/utils";
+import { menuBarStatus, menuBarStatusMarkdown, severityColor } from "./format";
+import {
+  analysisReport,
+  doctor,
+  normalizePreferences,
+  reportsDir,
+  scan,
+} from "./nightward";
+import type { MenuBarStatus } from "./format";
+import type { RiskLevel } from "./types";
+
+const docsUrl = "https://github.com/JSONbored/nightward#readme";
+
+export default function Command() {
+  const runtime = normalizePreferences(getPreferenceValues());
+  const { data, error, isLoading, revalidate } = usePromise(async () => {
+    const [report, doctorReport, analysis] = await Promise.all([
+      scan(runtime),
+      doctor(runtime),
+      analysisReport(runtime),
+    ]);
+    return {
+      status: menuBarStatus(report, doctorReport, analysis),
+      reportDir: doctorReport.schedule.report_dir,
+    };
+  });
+
+  if (error) {
+    return (
+      <MenuBarExtra
+        title="NW !"
+        icon={{ source: Icon.Warning, tintColor: Color.Red }}
+        tooltip={`Nightward failed: ${error.message}`}
+        isLoading={isLoading}
+      >
+        <MenuBarExtra.Section title="Nightward">
+          <MenuBarExtra.Item
+            title="Nightward Failed"
+            subtitle={error.message}
+          />
+          <MenuBarExtra.Item
+            title="Refresh"
+            icon={Icon.ArrowClockwise}
+            onAction={revalidate}
+          />
+          <MenuBarExtra.Item
+            title="Open Dashboard"
+            icon={Icon.Window}
+            onAction={() => void openCommand("dashboard")}
+          />
+          <MenuBarExtra.Item
+            title="Open Reports Folder"
+            icon={Icon.Folder}
+            onAction={() => void open(reportsDir(runtime.homeOverride))}
+          />
+        </MenuBarExtra.Section>
+      </MenuBarExtra>
+    );
+  }
+
+  const status = data?.status;
+  return (
+    <MenuBarExtra
+      title={status?.title ?? "NW"}
+      icon={{
+        source: statusIcon(status?.risk ?? "info"),
+        tintColor: severityColor(status?.risk ?? "info"),
+      }}
+      tooltip={status?.tooltip ?? "Loading Nightward status"}
+      isLoading={isLoading}
+    >
+      {status ? (
+        <StatusItems
+          status={status}
+          reportDir={data.reportDir}
+          onRefresh={revalidate}
+        />
+      ) : (
+        <MenuBarExtra.Item title="Loading Nightward status..." />
+      )}
+    </MenuBarExtra>
+  );
+}
+
+function StatusItems({
+  status,
+  reportDir,
+  onRefresh,
+}: {
+  status: MenuBarStatus;
+  reportDir: string;
+  onRefresh: () => void;
+}) {
+  return (
+    <>
+      <MenuBarExtra.Section title="Status">
+        <MenuBarExtra.Item
+          title={`${status.findings} findings`}
+          subtitle={`critical ${status.critical} - high ${status.high} - medium ${status.medium}`}
+          icon={{ source: Icon.Warning, tintColor: severityColor(status.risk) }}
+        />
+        <MenuBarExtra.Item
+          title={`${status.signals} analysis signals`}
+          subtitle={`${status.providerWarnings} provider warnings`}
+          icon={Icon.MagnifyingGlass}
+        />
+        <MenuBarExtra.Item
+          title={
+            status.scheduled ? "Scheduled scan installed" : "No scheduled scan"
+          }
+          subtitle={
+            status.lastFindings !== undefined
+              ? `${status.lastFindings} findings in last report`
+              : "no scheduled report yet"
+          }
+          icon={{
+            source: Icon.Clock,
+            tintColor: status.scheduled ? Color.Green : Color.Yellow,
+          }}
+        />
+      </MenuBarExtra.Section>
+
+      <MenuBarExtra.Section title="Open">
+        <MenuBarExtra.Item
+          title="Dashboard"
+          icon={Icon.Window}
+          onAction={() => void openCommand("dashboard")}
+        />
+        <MenuBarExtra.Item
+          title="Findings"
+          icon={Icon.List}
+          onAction={() => void openCommand("findings")}
+        />
+        <MenuBarExtra.Item
+          title="Provider Doctor"
+          icon={Icon.Heartbeat}
+          onAction={() => void openCommand("provider-doctor")}
+        />
+        <MenuBarExtra.Item
+          title="Reports Folder"
+          subtitle={reportDir}
+          icon={Icon.Folder}
+          onAction={() => void open(reportDir)}
+        />
+      </MenuBarExtra.Section>
+
+      <MenuBarExtra.Section title="Actions">
+        <MenuBarExtra.Item
+          title="Refresh"
+          icon={Icon.ArrowClockwise}
+          onAction={onRefresh}
+        />
+        <MenuBarExtra.Item
+          title="Copy Status Summary"
+          icon={Icon.Clipboard}
+          onAction={() => void copyStatus(status)}
+        />
+        <MenuBarExtra.Item
+          title="Open Nightward Docs"
+          icon={Icon.Book}
+          onAction={() => void open(docsUrl)}
+        />
+      </MenuBarExtra.Section>
+    </>
+  );
+}
+
+function statusIcon(risk: RiskLevel): Icon {
+  if (risk === "critical" || risk === "high") return Icon.ExclamationMark;
+  if (risk === "medium") return Icon.Warning;
+  return Icon.Shield;
+}
+
+async function openCommand(name: string) {
+  await launchCommand({ name, type: LaunchType.UserInitiated });
+}
+
+async function copyStatus(status: MenuBarStatus) {
+  await Clipboard.copy(menuBarStatusMarkdown(status));
+  await showHUD("Copied Nightward status");
+}

--- a/integrations/raycast/test/format.test.ts
+++ b/integrations/raycast/test/format.test.ts
@@ -3,13 +3,21 @@ import test from "node:test";
 import {
   analysisMarkdown,
   findingMarkdown,
+  menuBarStatus,
+  menuBarStatusMarkdown,
   maxSeverity,
   redactText,
   signalMarkdown,
   sortedFindings,
   sortedSignals,
 } from "../src/format";
-import type { AnalysisReport, AnalysisSignal, Finding } from "../src/types";
+import type {
+  AnalysisReport,
+  AnalysisSignal,
+  DoctorReport,
+  Finding,
+  ScanReport,
+} from "../src/types";
 
 test("redacts obvious secret assignments and long token-like values", () => {
   const keyName = "API_" + "KEY";
@@ -129,6 +137,72 @@ test("analysis markdown redacts signal evidence", () => {
   assert.equal(sortedSignals([baseSignal("b", "low"), signal])[0]?.id, "signal-a");
   assert.doesNotMatch(signalMarkdown(signal), /1234567890abcdef/);
   assert.doesNotMatch(analysisMarkdown(report), /1234567890abcdef/);
+});
+
+test("menu bar status summarizes risk and schedule state", () => {
+  const report: ScanReport = {
+    generated_at: "2026-05-01T00:00:00Z",
+    hostname: "fixture",
+    home: "/tmp/nightward-home",
+    summary: {
+      total_items: 2,
+      total_findings: 3,
+      items_by_classification: {},
+      items_by_risk: {},
+      items_by_tool: {},
+      findings_by_severity: { critical: 1, high: 1, medium: 1 },
+      findings_by_rule: {},
+      findings_by_tool: {},
+    },
+    items: [],
+    findings: [
+      baseFinding("critical", "critical", "Codex"),
+      baseFinding("high", "high", "Claude"),
+      baseFinding("medium", "medium", "Cursor"),
+    ],
+    adapters: [],
+  };
+  const doctor: DoctorReport = {
+    generated_at: "2026-05-01T00:00:00Z",
+    version: "0.1.4",
+    home: "/tmp/nightward-home",
+    executable: "/tmp/nw",
+    checks: [],
+    adapters: [],
+    schedule: {
+      preset: "daily",
+      platform: "darwin",
+      report_dir: "/tmp/reports",
+      log_dir: "/tmp/logs",
+      installed: true,
+      last_report: "/tmp/reports/latest.json",
+      last_findings: 2,
+    },
+  };
+  const analysis: AnalysisReport = {
+    generated_at: "2026-05-01T00:00:00Z",
+    mode: "home",
+    summary: {
+      total_subjects: 2,
+      total_signals: 4,
+      signals_by_severity: { high: 1 },
+      signals_by_category: { "execution-risk": 1 },
+      signals_by_provider: { nightward: 4 },
+      highest_severity: "high",
+      provider_warnings: 1,
+      no_known_risk_signals: false,
+    },
+    providers: [],
+    subjects: [],
+    signals: [],
+  };
+
+  const status = menuBarStatus(report, doctor, analysis);
+  assert.equal(status.title, "NW 1C");
+  assert.equal(status.risk, "critical");
+  assert.match(status.tooltip, /3 findings/);
+  assert.match(status.tooltip, /1 provider warnings/);
+  assert.match(menuBarStatusMarkdown(status), /Last scheduled findings: `2`/);
 });
 
 function baseFinding(

--- a/scripts/verify-npm-release.sh
+++ b/scripts/verify-npm-release.sh
@@ -22,8 +22,13 @@ console.log(`${metadata.name}@${metadata.version} ${metadata.dist.integrity}`);
 ' "${metadata}" "${package}" "${version}"
 
 tarball="$(npm pack "${package}@${version}" --silent --pack-destination "${tmp_dir}")"
+tar -xzf "${tmp_dir}/${tarball}" -C "${tmp_dir}"
+package_dir="${tmp_dir}/package"
 prefix="${tmp_dir}/prefix"
-npm install --global --prefix "${prefix}" "${tmp_dir}/${tarball}" --ignore-scripts --no-audit
+mkdir -p "${prefix}/bin"
+chmod 0755 "${package_dir}/bin/nightward.mjs"
+ln -s "${package_dir}/bin/nightward.mjs" "${prefix}/bin/nightward"
+ln -s "${package_dir}/bin/nightward.mjs" "${prefix}/bin/nw"
 
 PATH="${prefix}/bin:${PATH}" nightward --version | grep -Fx "${version}"
 PATH="${prefix}/bin:${PATH}" nw --version | grep -Fx "${version}"


### PR DESCRIPTION
## Summary
- adds a read-only Raycast menu-bar status command for Nightward findings, analysis signals, provider warnings, and scheduled-report state
- adds local test-suite aliases so fast, security, UX, release, and pre-push gates can be run before GitHub CI
- tightens release/npm verification to avoid `npm install` in Scorecard-flagged release smoke paths

## What changed
- Added `Nightward Status` as a Raycast menu-bar command with dashboard/findings/provider doctor/report-folder actions.
- Added menu-bar status formatting tests and generated Raycast command typings.
- Added `make test-fast`, `make test-security`, `make test-ux`, `make test-release`, `make test-local`, `make test-prepush`, and `make test-release-install`.
- Switched npm release verification and release workflow tarball smoke tests to direct tarball extraction/symlink checks instead of `npm install`.
- Added `.github/CODEOWNERS` to make CODEOWNERS review branch protection enforceable.
- Documented local suite usage, Raycast menu-bar behavior, and the single-maintainer admin-bypass caveat.

## Why
- Scorecard flagged pinned-dependency release smoke paths and branch-protection/code-review gaps.
- Local development needed clearer suite boundaries so release-sensitive branches can be validated before pushing.
- The Raycast extension already existed, but it lacked a menu-bar monitoring surface for quick local status checks.

## Validation
- `make test-prepush`
- `bash scripts/verify-npm-release.sh 0.1.4`
- `python3 /Users/shadowbook/.codex/skills/raycast-extension-engineer/scripts/audit_raycast_extension.py integrations/raycast`
- `npm test --prefix integrations/raycast`
- `npm run lint --prefix integrations/raycast`
- `npm run build --prefix integrations/raycast`
- `npm audit --audit-level=moderate --prefix integrations/raycast`
- `npm test --prefix packages/npm`
- `npm audit --audit-level=moderate --prefix packages/npm`

## Notes
- Local SSH commit signing is agent-backed and refused noninteractive signing in this environment, so this branch commit is DCO-signed but not cryptographically signed locally. Merge via GitHub squash/admin merge so the final protected `main` commit is GitHub-signed.
- Scorecard `Maintained`, `Code-Review`, and `CII-Best-Practices` still require maturity or external/manual action: repo age/activity, approved-review history from additional reviewers, and saving the OpenSSF Best Practices questionnaire.
