### PR TITLE
docs(release): update shipped distribution state

### DIFF
--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -4,11 +4,11 @@ Nightward distribution should optimize for trust first, then convenience.
 
 ## Order
 
-1. GitHub Releases with signed checksums and SBOMs.
-2. scoped npm launcher `@jsonbored/nightward` with trusted publishing and provenance.
-3. `go install github.com/jsonbored/nightward/cmd/nw@vX.Y.Z`.
-4. Trunk plugin import from a release tag.
-5. GitHub Action release tags.
+1. GitHub Releases with signed checksums and SBOMs. Shipped in `v0.1.4`.
+2. Scoped npm launcher `@jsonbored/nightward` with trusted publishing and provenance. Shipped in `v0.1.4`.
+3. `go install github.com/jsonbored/nightward/cmd/nw@vX.Y.Z`. Shipped.
+4. Trunk plugin import from a release tag. Shipped.
+5. GitHub Action release tags. Shipped.
 6. Homebrew tap.
 7. Nix flake/package.
 8. Scoop and WinGet.
@@ -18,7 +18,7 @@ Docker is deferred until Nightward has a useful local report browser. A containe
 
 ## NPM Posture
 
-The npm package is `@jsonbored/nightward`. It must remain a launcher:
+The npm package is `@jsonbored/nightward`. It is published through npm trusted publishing and must remain a launcher:
 
 - no `postinstall`
 - no bundled second implementation
@@ -26,11 +26,11 @@ The npm package is `@jsonbored/nightward`. It must remain a launcher:
 - trusted publishing with provenance
 - checksum verification before executing downloaded release archives
 
-## First Release Checklist
+## Ongoing Release Checklist
 
-1. Merge through reviewed PR.
+1. Merge through reviewed PR when a non-author reviewer exists, or document a solo-maintainer admin bypass.
 2. Confirm branch and tag protection.
-3. Configure npm trusted publishing for `.github/workflows/release.yml`.
+3. Confirm npm trusted publishing for `.github/workflows/release.yml`.
 4. Run local verification.
 5. Create a signed SemVer tag.
 6. Verify GitHub release artifacts.

--- a/docs/install.md
+++ b/docs/install.md
@@ -43,7 +43,7 @@ npm install -g @jsonbored/nightward
 nw scan --json
 ```
 
-Publishing is disabled by default. The release workflow publishes to npm only when `NPM_PUBLISH=true` is configured and npm trusted publishing is ready for package `@jsonbored/nightward`, repository `JSONbored/nightward`, and workflow `.github/workflows/release.yml`.
+Publishing is release-gated. The release workflow publishes to npm only when `NPM_PUBLISH=true` is configured for a release tag and npm trusted publishing is configured for package `@jsonbored/nightward`, repository `JSONbored/nightward`, and workflow `.github/workflows/release.yml`.
 
 The package should not use a long-lived npm token. It should publish through GitHub OIDC/trusted publishing with provenance.
 

--- a/docs/openssf-best-practices.md
+++ b/docs/openssf-best-practices.md
@@ -20,7 +20,7 @@ Project badge: <https://www.bestpractices.dev/projects/12713>
 - Dynamic analysis: automated tests, race tests, Raycast tests/build, and Go fuzz smoke tests.
 - Secret scanning: Gitleaks in CI and `make gitleaks`.
 - Release notes: <https://github.com/JSONbored/nightward/blob/main/CHANGELOG.md>
-- Maintained status evidence: reviewed PRs, CI-green `main`, Renovate dependency updates, issue response history, and signed release tags.
+- Maintained status evidence: CI-green `main`, Renovate dependency updates, issue response history, immutable signed release tags, and published release artifacts. Scorecard's repository-age portion still needs time to age out.
 
 ## N/A Crypto Fields
 
@@ -40,6 +40,8 @@ The release pipeline uses external tools for signing release checksums and SBOM 
 - Release readiness: `.goreleaser.yml`, `make release-snapshot`, signed checksum config, SBOM config, release workflow, release smoke, and trusted-publishing-only npm launcher package.
 - Website/docs readiness: `site/` VitePress source and `.github/workflows/pages.yml`.
 - Distribution plan: <https://github.com/JSONbored/nightward/blob/main/docs/distribution.md>
+- npm provenance: `@jsonbored/nightward` publishes through trusted publishing/OIDC with provenance and no long-lived npm token.
+- GitHub Pages: <https://jsonbored.github.io/nightward/>
 
 ## Gold-Oriented Backlog
 
@@ -57,6 +59,4 @@ These cannot be completed by repository files alone:
 - Keep GitHub branch protection/rulesets requiring reviewed PRs and status checks.
 - Keep maintainer 2FA enabled.
 - Let Scorecard `Maintained` age out after the repository is older than 90 days.
-- Improve Scorecard `Code-Review` through future reviewed PR history.
-- Configure npm trusted publishing before setting `NPM_PUBLISH=true`.
-- Enable GitHub Pages for the repository after the site workflow is merged.
+- Improve Scorecard `Code-Review` through future reviewed PR history once a second reviewer or maintainer exists.

--- a/docs/website.md
+++ b/docs/website.md
@@ -61,4 +61,4 @@ Design one polished landing page first. Keep it dark, operator-focused, and conc
 
 ## Deployment
 
-The first deployment target is GitHub Pages via `.github/workflows/pages.yml`. A custom domain can be added later without changing the framework.
+The current deployment target is GitHub Pages via `.github/workflows/pages.yml`: <https://jsonbored.github.io/nightward/>. A custom domain can be added later without changing the framework.


### PR DESCRIPTION
## Summary
- update maintenance docs to reflect that GitHub Pages and npm trusted publishing are now shipped
- keep OpenSSF evidence focused on the remaining external blockers

## What changed
- marks GitHub Releases, scoped npm launcher, go install, Trunk, and GitHub Action release-tag channels as shipped
- changes the first-release checklist into an ongoing release checklist
- removes stale Pages/npm setup items from the OpenSSF manual-action list
- updates install and website docs with the current release-gated npm and GitHub Pages posture

## Why
- the repo was still describing shipped release infrastructure as future setup work
- issue #10 and Scorecard triage need the docs to distinguish code-fixed items from account/time-based maturity blockers

## Validation
- `make site-verify`
- `node scripts/check-docs-freshness.mjs`
- `git diff --check`

## Notes
- remaining OpenSSF blockers are still external/account or maturity driven: bestpractices.dev questionnaire, repository age, and future reviewed PR history
