### PR TITLE
feat(remediation): improve dogfood review flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Formal changelog entries begin with the first tagged release.
 
 ## Unreleased
 
+- Collapsed redundant `mcp_server_review` noise when stronger server-specific findings already exist.
+- Added grouped fix-plan review items for repeated package-pin remediation.
+- Added compact MCP policy output for AI-client status checks.
+- Improved CLI/Raycast provider-token redaction and scoped Raycast fix-plan actions.
 - Replaced pre-1.0 deterministic SHA-1 IDs with SHA-256-backed IDs while preserving the short ID shape.
 - Added OpenSSF Silver-ready governance, threat model, DCO, coverage, and release snapshot hardening.
 - Added a release-gated npm launcher package that downloads GitHub Release binaries on first run without `postinstall`.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -18,6 +18,10 @@ The server follows the MCP JSON-RPC lifecycle for `initialize`, `tools/list`, `t
 - `nightward_report_changes`
 - `nightward_policy_check`
 
+`nightward_policy_check` accepts `compact: true` for AI-client friendly output.
+Compact mode keeps pass/fail, threshold, summary counts, and bounded violation
+metadata without returning every full finding or policy-ignore detail.
+
 ## Exposed Resources
 
 - `nightward://rules`
@@ -45,4 +49,6 @@ Use an absolute `command` path if the AI client does not inherit the same `PATH`
 - Output is bounded before it is returned to the MCP client.
 - Nightward reports provider or tool execution errors as tool results with `isError: true`.
 - The MCP server can include offline analysis, but it does not enable online providers in v1.
+- Use `compact: true` for casual policy checks in chat clients; request the full
+  policy report only when you need complete local review material.
 - Any future write-capable MCP tool must require a separate design review, confirmation UX, rollback story, and redaction tests.

--- a/docs/raycast-extension.md
+++ b/docs/raycast-extension.md
@@ -11,8 +11,8 @@ integrations/raycast
 ## Commands
 
 - `Nightward Dashboard`: scan counts, schedule status, adapter summary, and top findings.
-- `Nightward Status`: menu-bar counter for finding severity, analysis signals, provider warnings, scheduled-report state, and latest-report access.
-- `Nightward Findings`: searchable findings with a severity filter, detail pane, and copy/open-doc actions.
+- `Nightward Status`: compact menu-bar severity marker such as `3C`, `18H`, or `59`, with full critical/high/total counts, analysis signals, provider warnings, scheduled-report state, and latest-report access in the dropdown.
+- `Nightward Findings`: searchable findings with a severity filter, detail pane, scoped fix-plan exports, reviewed-policy-ignore snippets, redacted evidence copy, and open-doc actions.
 - `Nightward Analysis`: built-in offline signals plus explicitly selected providers.
 - `Nightward Provider Doctor`: optional provider availability, privacy posture, and Raycast Analysis enable/disable controls.
 - `Explain Nightward Finding`: detail view for a known finding ID.
@@ -37,6 +37,8 @@ The extension uses `execFile`, not a shell, for local Nightward commands. It cal
 - `findings explain <id> --json`
 - `fix plan --json`
 - `fix export --all --format markdown`
+- `fix export --finding <id> --format markdown`
+- `fix export --rule <rule> --format markdown`
 - `analyze [--with providers] [--online] --json`
 - `analyze finding <id> --json`
 - `providers doctor [--with providers] [--online] --json`
@@ -66,7 +68,7 @@ Manual smoke must use a fixture `Home Override`, not a real local home, before s
 
 - Dashboard loads scan counts, schedule status, adapters, and top findings.
 - Menu-bar status shows finding, analysis, provider-warning, and schedule counters; its actions open existing read-only commands, open the latest report when present, and copy a redacted summary.
-- Findings search/filter/detail panes render redacted evidence and docs actions.
+- Findings search/filter/detail panes render redacted evidence, docs actions, scoped fix-plan exports, and reviewed-policy-ignore snippets.
 - Analysis renders built-in signals, selected provider output, provider warnings, and blocked-online-provider state.
 - Provider Doctor shows provider status and lets users enable or disable providers for Raycast Analysis without running online-capable providers unless explicit opt-in is enabled.
 - Export commands copy redacted Markdown and do not mutate local config.

--- a/docs/remediation.md
+++ b/docs/remediation.md
@@ -17,6 +17,16 @@ Nightward remediation is plan-only. It recommends changes, explains risk, and ca
 
 Package pinning does not guess versions. Choose a reviewed version from the upstream registry or release notes, then edit the package token manually.
 
+`nw fix plan` groups repeated review work where Nightward can identify a shared
+root cause. For example, repeated `mcp-remote` unpinned-package findings are
+summarized as one grouped review item so the same reviewed version can be
+applied consistently instead of triaging dozens of identical hints.
+
+Advisory `mcp_server_review` findings are collapsed when the same server already
+has a higher-severity finding. The stronger finding remains the review anchor,
+which keeps Raycast, HTML reports, MCP output, and policy results focused on the
+actionable risk.
+
 ## Rule Guidance
 
 ### mcp_secret_env

--- a/integrations/raycast/CHANGELOG.md
+++ b/integrations/raycast/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Use compact menu-bar status markers such as `3C` and move detailed counts into the dropdown.
+- Add scoped finding and rule fix-plan copy actions plus reviewed-policy-ignore snippets.
+- Redact additional provider token-shaped values in Raycast-rendered text.
+
 ## 0.1.0
 
 - Add read-only Dashboard, Findings, Explain Finding, Export Fix Plan, and Open Reports commands.

--- a/integrations/raycast/README.md
+++ b/integrations/raycast/README.md
@@ -2,13 +2,13 @@
 
 Run Nightward scans, findings, provider checks, and redacted fix-plan exports from Raycast.
 
-This extension is read-only. It runs local `nw`/`nightward` commands, renders redacted JSON output, copies user-requested fix-plan text, and opens the scheduled report folder. It does not install schedules, edit agent configs, restore files, push to Git, or copy secret values.
+This extension is read-only. It runs local `nw`/`nightward` commands, renders redacted JSON output, copies user-requested fix-plan and policy-review text, and opens the scheduled report folder. It does not install schedules, edit agent configs, restore files, push to Git, or copy secret values.
 
 ## Commands
 
 - `Nightward Dashboard`: scan summary, schedule status, adapters, and top findings.
-- `Nightward Status`: menu-bar counter for findings, analysis signals, provider warnings, and scheduled-report state.
-- `Nightward Findings`: searchable findings with severity filters and detail panes.
+- `Nightward Status`: compact menu-bar marker such as `3C`, `18H`, or a total count, with detailed findings, analysis signals, provider warnings, and scheduled-report state in the dropdown.
+- `Nightward Findings`: searchable findings with severity filters, detail panes, scoped fix-plan exports, reviewed-policy-ignore snippets, and redacted evidence copy.
 - `Nightward Analysis`: built-in offline analysis plus any providers explicitly selected in Provider Doctor.
 - `Nightward Provider Doctor`: provider availability, privacy posture, and Raycast Analysis enable/disable controls.
 - `Explain Nightward Finding`: detail view for a specific finding ID.

--- a/integrations/raycast/src/dashboard.tsx
+++ b/integrations/raycast/src/dashboard.tsx
@@ -322,6 +322,12 @@ function FixPlanDetail({ plan }: { plan: FixPlan }) {
     "",
     "Nightward exports fix plans only. It does not mutate local configs from Raycast.",
   ];
+  if (plan.groups && plan.groups.length > 0) {
+    lines.push("", "## Grouped Review");
+    for (const group of plan.groups.slice(0, 8)) {
+      lines.push(`- \`${group.label}\` (${group.count}): ${group.summary}`);
+    }
+  }
   return <List.Item.Detail markdown={lines.join("\n")} />;
 }
 

--- a/integrations/raycast/src/findings.tsx
+++ b/integrations/raycast/src/findings.tsx
@@ -1,11 +1,15 @@
 import {
   Action,
   ActionPanel,
+  Clipboard,
   Color,
   Detail,
   Icon,
   List,
   getPreferenceValues,
+  showHUD,
+  showToast,
+  Toast,
 } from "@raycast/api";
 import { usePromise } from "@raycast/utils";
 import { useState } from "react";
@@ -15,10 +19,16 @@ import {
   findingMarkdown,
   findingSubtitle,
   findingTitle,
+  policyIgnoreSnippet,
+  redactText,
   severityColor,
   sortedFindings,
 } from "./format";
-import { findings, normalizePreferences } from "./nightward";
+import {
+  exportFixPlanMarkdown,
+  findings,
+  normalizePreferences,
+} from "./nightward";
 import type { Finding, RiskLevel } from "./types";
 
 const docsUrl =
@@ -162,24 +172,80 @@ function FindingActions({
   finding: Finding;
   onRefresh: () => void;
 }) {
+  const runtime = normalizePreferences(getPreferenceValues());
   const firstStep = finding.fix_steps?.[0] ?? finding.recommended_action;
   return (
     <ActionPanel>
-      <Action.CopyToClipboard title="Copy Finding ID" content={finding.id} />
-      <Action.CopyToClipboard
-        title="Copy Recommended Action"
-        content={firstStep}
-      />
-      <Action.CopyToClipboard title="Copy Path" content={finding.path} />
-      {finding.docs_url ? (
-        <Action.OpenInBrowser
-          title="Open Finding Docs"
-          url={finding.docs_url}
+      <ActionPanel.Section title="Review">
+        <Action.CopyToClipboard title="Copy Finding ID" content={finding.id} />
+        <Action.CopyToClipboard
+          title="Copy Recommended Action"
+          content={redactText(firstStep)}
         />
-      ) : (
-        <Action.OpenInBrowser title="Open Remediation Docs" url={docsUrl} />
-      )}
-      <Action title="Refresh" icon={Icon.ArrowClockwise} onAction={onRefresh} />
+        <Action.CopyToClipboard title="Copy Path" content={finding.path} />
+        <Action.CopyToClipboard
+          title="Copy Reviewed Policy Ignore Snippet"
+          icon={Icon.CheckCircle}
+          content={policyIgnoreSnippet(finding)}
+        />
+      </ActionPanel.Section>
+      <ActionPanel.Section title="Plan-Only Remediation">
+        <Action
+          title="Copy Fix Plan for Finding"
+          icon={Icon.Document}
+          onAction={async () =>
+            copyFixPlan(
+              runtime,
+              { findingId: finding.id },
+              "Copied finding fix plan",
+            )
+          }
+        />
+        <Action
+          title="Copy Fix Plan for Rule"
+          icon={Icon.List}
+          onAction={async () =>
+            copyFixPlan(runtime, { rule: finding.rule }, "Copied rule fix plan")
+          }
+        />
+      </ActionPanel.Section>
+      <ActionPanel.Section title="Open">
+        <Action.CopyToClipboard
+          title="Copy Redacted Evidence"
+          content={redactText(finding.evidence ?? "")}
+        />
+        {finding.docs_url ? (
+          <Action.OpenInBrowser
+            title="Open Finding Docs"
+            url={finding.docs_url}
+          />
+        ) : (
+          <Action.OpenInBrowser title="Open Remediation Docs" url={docsUrl} />
+        )}
+        <Action
+          title="Refresh"
+          icon={Icon.ArrowClockwise}
+          onAction={onRefresh}
+        />
+      </ActionPanel.Section>
     </ActionPanel>
   );
+}
+
+async function copyFixPlan(
+  runtime: ReturnType<typeof normalizePreferences>,
+  selector: { findingId?: string; rule?: string },
+  message: string,
+) {
+  try {
+    await Clipboard.copy(await exportFixPlanMarkdown(runtime, selector));
+    await showHUD(message);
+  } catch (error) {
+    await showToast({
+      style: Toast.Style.Failure,
+      title: "Could not export fix plan",
+      message:
+        error instanceof Error ? error.message : "Unknown Nightward error",
+    });
+  }
 }

--- a/integrations/raycast/src/format.ts
+++ b/integrations/raycast/src/format.ts
@@ -12,7 +12,8 @@ import type {
 
 const secretAssignmentPattern =
   /((?:token|secret|password|passwd|api[_-]?key|auth|credential|private[_-]?key)[\w.-]*\s*[:=]\s*)(["']?)[^"',\s}]+/gi;
-const longSecretLikePattern = /\bsk-[A-Za-z0-9_-]{12,}\b/g;
+const providerTokenPattern =
+  /\b(?:sk-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9_]{20,}|glpat-[A-Za-z0-9_-]{20,}|npm_[A-Za-z0-9]{20,}|xox[abprs]-[A-Za-z0-9-]{20,}|eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,})\b/g;
 
 const riskRank: Record<RiskLevel, number> = {
   info: 0,
@@ -24,9 +25,13 @@ const riskRank: Record<RiskLevel, number> = {
 
 export function redactText(value: string | undefined): string {
   if (!value) return "";
-  return value
+  const redacted = value
     .replace(secretAssignmentPattern, "$1$2[redacted]")
-    .replace(longSecretLikePattern, "[redacted]");
+    .replace(providerTokenPattern, "[redacted]");
+  return redacted
+    .split(/(\s+)/)
+    .map((part) => (looksOpaqueProviderToken(part) ? "[redacted]" : part))
+    .join("");
 }
 
 export function severityColor(severity: RiskLevel): string {
@@ -315,22 +320,26 @@ export function menuBarStatus(
   const critical = report.summary.findings_by_severity.critical ?? 0;
   const high = report.summary.findings_by_severity.high ?? 0;
   const medium = report.summary.findings_by_severity.medium ?? 0;
+  const low = report.summary.findings_by_severity.low ?? 0;
+  const info = report.summary.findings_by_severity.info ?? 0;
   const findings = report.summary.total_findings;
   const signals = analysis.summary.total_signals;
   const providerWarnings = analysis.summary.provider_warnings;
   const historyDelta = reportHistoryDelta(doctor.schedule.history);
   const issueCount = findings + providerWarnings;
-  const topCount =
-    critical > 0
-      ? critical
-      : high > 0
-        ? high
-        : medium > 0
-          ? medium
-          : issueCount;
-  const title = issueCount === 0 ? "" : String(topCount);
+  const title =
+    issueCount === 0
+      ? ""
+      : critical > 0
+        ? `${critical}C`
+        : high > 0
+          ? `${high}H`
+          : medium > 0
+            ? `${medium}M`
+            : String(issueCount);
   const tooltip = [
-    `${findings} findings`,
+    `${critical} critical / ${high} high / ${findings} total findings`,
+    low > 0 || info > 0 ? `${medium} medium / ${low} low / ${info} info` : "",
     `${signals} analysis signals`,
     `${providerWarnings} provider warnings`,
     `max risk: ${risk}`,
@@ -355,6 +364,17 @@ export function menuBarStatus(
     lastReport: doctor.schedule.last_report,
     historyDelta,
   };
+}
+
+export function policyIgnoreSnippet(
+  finding: Finding,
+  reason = "reviewed locally",
+): string {
+  return [
+    "ignore_findings:",
+    `  - id: ${JSON.stringify(finding.id)}`,
+    `    reason: ${JSON.stringify(reason)}`,
+  ].join("\n");
 }
 
 export function menuBarStatusMarkdown(status: MenuBarStatus): string {
@@ -445,6 +465,21 @@ function maxBacktickRun(value: string): number {
     }
   }
   return max;
+}
+
+function looksOpaqueProviderToken(value: string): boolean {
+  const trimmed = value.replace(/^["'`,]+|["'`,.]+$/g, "");
+  if (
+    trimmed.length < 36 ||
+    trimmed.includes("/") ||
+    trimmed.includes("\\") ||
+    trimmed.includes("@") ||
+    trimmed.includes(".") ||
+    !/^[A-Za-z0-9_-]+$/.test(trimmed)
+  ) {
+    return false;
+  }
+  return /\d/.test(trimmed) && /[A-Za-z]/.test(trimmed);
 }
 
 const markdownSpecialChars = new Set([

--- a/integrations/raycast/src/nightward.ts
+++ b/integrations/raycast/src/nightward.ts
@@ -93,8 +93,19 @@ export async function explainFinding(
   );
 }
 
-export async function fixPlan(options: RuntimeOptions): Promise<FixPlan> {
-  return runNightwardJSON<FixPlan>(["fix", "plan", "--all", "--json"], options);
+export type FixPlanSelector = {
+  findingId?: string;
+  rule?: string;
+};
+
+export async function fixPlan(
+  options: RuntimeOptions,
+  selector: FixPlanSelector = {},
+): Promise<FixPlan> {
+  return runNightwardJSON<FixPlan>(
+    ["fix", "plan", ...fixSelectorArgs(selector), "--json"],
+    options,
+  );
 }
 
 export async function analysisReport(
@@ -181,9 +192,10 @@ export async function exportAnalysisMarkdown(
 
 export async function exportFixPlanMarkdown(
   options: RuntimeOptions,
+  selector: FixPlanSelector = {},
 ): Promise<string> {
   return runNightwardText(
-    ["fix", "export", "--all", "--format", "markdown"],
+    ["fix", "export", ...fixSelectorArgs(selector), "--format", "markdown"],
     options,
   );
 }
@@ -271,6 +283,12 @@ function execNightward(
 
 function commandLabel(executable: string, args: string[]): string {
   return [executable, ...args].join(" ");
+}
+
+function fixSelectorArgs(selector: FixPlanSelector): string[] {
+  if (selector.findingId) return ["--finding", selector.findingId];
+  if (selector.rule) return ["--rule", selector.rule];
+  return ["--all"];
 }
 
 function raycastCommandPath(executable: string): string {

--- a/integrations/raycast/src/types.ts
+++ b/integrations/raycast/src/types.ts
@@ -205,12 +205,29 @@ export type FixPlan = {
     review: number;
     blocked: number;
   };
+  groups?: Array<{
+    key: string;
+    label: string;
+    rule: string;
+    fix_kind?: FixKind;
+    package?: string;
+    severity: RiskLevel;
+    status: "safe" | "review" | "blocked";
+    count: number;
+    finding_ids: string[];
+    paths?: string[];
+    servers?: string[];
+    summary: string;
+    steps?: string[];
+  }>;
   fixes: Array<{
     finding_id: string;
     tool: string;
     path: string;
+    server?: string;
     severity: RiskLevel;
     rule: string;
+    package?: string;
     fix_available: boolean;
     fix_kind?: FixKind;
     confidence?: string;

--- a/integrations/raycast/test/format.test.ts
+++ b/integrations/raycast/test/format.test.ts
@@ -6,6 +6,7 @@ import {
   menuBarStatus,
   menuBarStatusMarkdown,
   maxSeverity,
+  policyIgnoreSnippet,
   redactText,
   reportHistoryDelta,
   signalMarkdown,
@@ -23,11 +24,17 @@ import type {
 test("redacts obvious secret assignments and long token-like values", () => {
   const keyName = "API_" + "KEY";
   const token = "sk-" + "1234567890abcdef";
+  const jwt =
+    "eyJhbGciOiJIUzI1" +
+    "NiJ9.eyJzdWIiOiIx" +
+    "MjM0NTY3ODkwIn0." +
+    "signatureValue123";
+  const opaque = "providerTokenValue1234567890abcdefABCDEF";
   const longValue = "abcdefghijklmno" + "pqrstuvwxyz123456";
   const path =
     "/Users/example/Library/Application Support/Claude/claude_desktop_config.json";
   const output = redactText(
-    `${keyName}=${token} secret: ${longValue} path: ${path}`,
+    `${keyName}=${token} secret: ${longValue} jwt: ${jwt} opaque: ${opaque} path: ${path}`,
   );
   assert.match(output, /API_KEY=\[redacted\]/);
   assert.match(output, /secret: \[redacted\]/);
@@ -37,6 +44,8 @@ test("redacts obvious secret assignments and long token-like values", () => {
   );
   assert.doesNotMatch(output, /1234567890abcdef/);
   assert.doesNotMatch(output, /abcdefghijklmnopqrstuvwxyz123456/);
+  assert.doesNotMatch(output, /eyJhbGci/);
+  assert.doesNotMatch(output, /providerTokenValue/);
 });
 
 test("finding markdown keeps guidance while avoiding secret values", () => {
@@ -215,9 +224,9 @@ test("menu bar status summarizes risk and schedule state", () => {
   };
 
   const status = menuBarStatus(report, doctor, analysis);
-  assert.equal(status.title, "1");
+  assert.equal(status.title, "1C");
   assert.equal(status.risk, "critical");
-  assert.match(status.tooltip, /3 findings/);
+  assert.match(status.tooltip, /1 critical \/ 1 high \/ 3 total findings/);
   assert.match(status.tooltip, /1 provider warnings/);
   assert.equal(status.historyDelta, "+2 findings");
   assert.match(menuBarStatusMarkdown(status), /Last scheduled findings: `2`/);
@@ -225,6 +234,13 @@ test("menu bar status summarizes risk and schedule state", () => {
     menuBarStatusMarkdown(status),
     /Change since previous scheduled scan: `\+2 findings`/,
   );
+});
+
+test("policy ignore snippets are explicit and reasoned", () => {
+  const snippet = policyIgnoreSnippet(baseFinding("finding-a", "info", "Codex"));
+  assert.match(snippet, /ignore_findings:/);
+  assert.match(snippet, /"finding-a"/);
+  assert.match(snippet, /"reviewed locally"/);
 });
 
 test("report history delta handles missing and equal histories", () => {

--- a/integrations/raycast/test/nightward.test.ts
+++ b/integrations/raycast/test/nightward.test.ts
@@ -3,6 +3,8 @@ import test from "node:test";
 import {
   analysisReport,
   explainFinding,
+  exportFixPlanMarkdown,
+  fixPlan,
   normalizePreferences,
   providersDoctor,
   reportsDir,
@@ -215,6 +217,50 @@ test("provider doctor reflects selected providers and online preference", async 
     "socket",
     "--online",
     "--json",
+  ]);
+});
+
+test("fix plan helpers pass scoped selectors", async () => {
+  const observed: string[][] = [];
+  const options: RuntimeOptions = {
+    executable: "nightward",
+    allowOnlineProviders: false,
+    timeoutMs: 1000,
+    execFileImpl: (_file, args, _options, callback) => {
+      observed.push(args);
+      if (args.includes("export")) {
+        callback(null, "# Nightward Fix Plan\n", "");
+        return;
+      }
+      callback(
+        null,
+        JSON.stringify({
+          generated_at: "2026-05-01T00:00:00Z",
+          summary: { total: 0, safe: 0, review: 0, blocked: 0 },
+          fixes: [],
+        }),
+        "",
+      );
+    },
+  };
+
+  await fixPlan(options, { rule: "mcp_unpinned_package" });
+  await exportFixPlanMarkdown(options, { findingId: "finding-123" });
+
+  assert.deepEqual(observed[0], [
+    "fix",
+    "plan",
+    "--rule",
+    "mcp_unpinned_package",
+    "--json",
+  ]);
+  assert.deepEqual(observed[1], [
+    "fix",
+    "export",
+    "--finding",
+    "finding-123",
+    "--format",
+    "markdown",
   ]);
 });
 

--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -233,10 +233,11 @@ func TestProviderParsersCoverSupportedFormats(t *testing.T) {
 
 func TestOnlineProviderParsersRedactSecretLikeFields(t *testing.T) {
 	root := "/tmp/workspace"
+	opaqueToken := "providerTokenValue1234567890abcdefABCDEF"
 	cases := map[string]string{
-		"trivy":       `{"Results":[{"Target":"/tmp/workspace/package-lock.json","Vulnerabilities":[{"VulnerabilityID":"CVE-2026-0001","PkgName":"demo","Severity":"CRITICAL","Title":"API_TOKEN=super-secret-value vulnerable dependency"}],"Misconfigurations":[{"ID":"AVD-1","Severity":"MEDIUM","Title":"password=super-secret-value in config"}],"Secrets":[{"RuleID":"aws-access-key","Severity":"HIGH","Target":"/tmp/workspace/.env","Title":"private_key=super-secret-value"}]}]}`,
-		"osv-scanner": `{"results":[{"source":{"path":"/tmp/workspace/package-lock.json","type":"lockfile"},"packages":[{"package":{"name":"demo"},"vulnerabilities":[{"id":"GHSA-123","summary":"api_key=super-secret-value vulnerable package"}]}]},{"path":"/tmp/workspace/go.mod","vulnerabilities":[{"id":"GO-2026-0001","details":"password=super-secret-value detail"}]}]}`,
-		"socket":      `{"issues":[{"type":"malware","severity":"high","message":"API_TOKEN=super-secret-value","package":{"name":"demo"},"file":"package.json"}],"scanId":"scan_123"}`,
+		"trivy":       `{"Results":[{"Target":"/tmp/workspace/package-lock.json","Vulnerabilities":[{"VulnerabilityID":"CVE-2026-0001","PkgName":"demo","Severity":"CRITICAL","Title":"API_TOKEN=super-secret-value ` + opaqueToken + ` vulnerable dependency"}],"Misconfigurations":[{"ID":"AVD-1","Severity":"MEDIUM","Title":"password=super-secret-value in config"}],"Secrets":[{"RuleID":"aws-access-key","Severity":"HIGH","Target":"/tmp/workspace/.env","Title":"private_key=super-secret-value"}]}]}`,
+		"osv-scanner": `{"results":[{"source":{"path":"/tmp/workspace/package-lock.json","type":"lockfile"},"packages":[{"package":{"name":"demo"},"vulnerabilities":[{"id":"GHSA-123","summary":"api_key=super-secret-value vulnerable package"}]}]},{"path":"/tmp/workspace/go.mod","vulnerabilities":[{"id":"GO-2026-0001","details":"password=super-secret-value ` + opaqueToken + ` detail"}]}]}`,
+		"socket":      `{"issues":[{"type":"malware","severity":"high","message":"API_TOKEN=super-secret-value ` + opaqueToken + `","package":{"name":"demo"},"file":"package.json"}],"scanId":"scan_123"}`,
 	}
 	for provider, output := range cases {
 		findings, err := parseProviderOutput(provider, root, output)
@@ -252,6 +253,9 @@ func TestOnlineProviderParsersRedactSecretLikeFields(t *testing.T) {
 		}
 		if strings.Contains(string(data), "super-secret-value") {
 			t.Fatalf("%s parser leaked provider secret material: %s", provider, data)
+		}
+		if strings.Contains(string(data), opaqueToken) {
+			t.Fatalf("%s parser leaked opaque provider token: %s", provider, data)
 		}
 		if !strings.Contains(string(data), "[redacted]") {
 			t.Fatalf("%s parser did not preserve redaction marker: %s", provider, data)

--- a/internal/analysis/providers.go
+++ b/internal/analysis/providers.go
@@ -59,6 +59,7 @@ func (b *limitedBuffer) String() string {
 }
 
 var providerSecretPattern = regexp.MustCompile(`(?i)((?:token|secret|password|passwd|api[_-]?key|auth|credential|private[_-]?key)[\w.-]*\s*[:=]\s*)(["']?)[^"',\s}]+`)
+var providerTokenPattern = regexp.MustCompile(`(?i)\b(?:sk-[a-z0-9_-]{12,}|gh[pousr]_[a-z0-9_]{20,}|glpat-[a-z0-9_-]{20,}|npm_[a-z0-9]{20,}|xox[abprs]-[a-z0-9-]{20,}|eyj[a-z0-9_-]{8,}\.[a-z0-9_-]{8,}\.[a-z0-9_-]{8,})\b`)
 
 func appendProviderSignals(out *Report, report inventory.Report, options Options) {
 	selected := selectedProviders(options.With)
@@ -604,8 +605,42 @@ func firstProviderLine(value string) string {
 
 func redactProviderText(value string) string {
 	value = providerSecretPattern.ReplaceAllString(value, "$1$2[redacted]")
+	value = providerTokenPattern.ReplaceAllString(value, "[redacted]")
+	value = strings.Join(redactOpaqueProviderTokens(strings.Fields(value)), " ")
 	if len(value) > 500 {
 		return value[:500] + "..."
 	}
 	return value
+}
+
+func redactOpaqueProviderTokens(parts []string) []string {
+	out := append([]string(nil), parts...)
+	for i, part := range out {
+		trimmed := strings.Trim(part, "\"'`,")
+		if looksOpaqueProviderToken(trimmed) {
+			out[i] = strings.Replace(part, trimmed, "[redacted]", 1)
+		}
+	}
+	return out
+}
+
+func looksOpaqueProviderToken(part string) bool {
+	if len(part) < 36 || strings.ContainsAny(part, `/\`) || strings.Contains(part, "@") || strings.Contains(part, ".") {
+		return false
+	}
+	var hasLower, hasUpper, hasDigit bool
+	for _, r := range part {
+		switch {
+		case r >= 'a' && r <= 'z':
+			hasLower = true
+		case r >= 'A' && r <= 'Z':
+			hasUpper = true
+		case r >= '0' && r <= '9':
+			hasDigit = true
+		case r == '-' || r == '_':
+		default:
+			return false
+		}
+	}
+	return hasDigit && (hasLower || hasUpper)
 }

--- a/internal/fixplan/plan.go
+++ b/internal/fixplan/plan.go
@@ -27,6 +27,7 @@ type Plan struct {
 	SchemaVersion int       `json:"schema_version"`
 	GeneratedAt   time.Time `json:"generated_at"`
 	Summary       Summary   `json:"summary"`
+	Groups        []Group   `json:"groups,omitempty"`
 	Fixes         []Fix     `json:"fixes"`
 }
 
@@ -41,8 +42,10 @@ type Fix struct {
 	FindingID      string              `json:"finding_id"`
 	Tool           string              `json:"tool"`
 	Path           string              `json:"path"`
+	Server         string              `json:"server,omitempty"`
 	Severity       inventory.RiskLevel `json:"severity"`
 	Rule           string              `json:"rule"`
+	Package        string              `json:"package,omitempty"`
 	FixAvailable   bool                `json:"fix_available"`
 	FixKind        inventory.FixKind   `json:"fix_kind,omitempty"`
 	Confidence     string              `json:"confidence,omitempty"`
@@ -54,6 +57,22 @@ type Fix struct {
 	Evidence       string              `json:"evidence,omitempty"`
 	Impact         string              `json:"impact,omitempty"`
 	Why            string              `json:"why_this_matters,omitempty"`
+}
+
+type Group struct {
+	Key        string              `json:"key"`
+	Label      string              `json:"label"`
+	Rule       string              `json:"rule"`
+	FixKind    inventory.FixKind   `json:"fix_kind,omitempty"`
+	Package    string              `json:"package,omitempty"`
+	Severity   inventory.RiskLevel `json:"severity"`
+	Status     Status              `json:"status"`
+	Count      int                 `json:"count"`
+	FindingIDs []string            `json:"finding_ids"`
+	Paths      []string            `json:"paths,omitempty"`
+	Servers    []string            `json:"servers,omitempty"`
+	Summary    string              `json:"summary"`
+	Steps      []string            `json:"steps,omitempty"`
 }
 
 func Build(report inventory.Report, selector Selector) Plan {
@@ -74,6 +93,7 @@ func Build(report inventory.Report, selector Selector) Plan {
 			plan.Summary.Blocked++
 		}
 	}
+	plan.Groups = groupFixes(plan.Fixes)
 	sort.Slice(plan.Fixes, func(i, j int) bool {
 		if plan.Fixes[i].Status == plan.Fixes[j].Status {
 			if plan.Fixes[i].Severity == plan.Fixes[j].Severity {
@@ -113,11 +133,28 @@ func Markdown(plan Plan) string {
 		b.WriteString("No fixes matched the selected findings.\n")
 		return b.String()
 	}
+	if len(plan.Groups) > 0 {
+		b.WriteString("## Grouped Review\n\n")
+		for _, group := range plan.Groups {
+			fmt.Fprintf(&b, "- `%s` (%d finding", group.Label, group.Count)
+			if group.Count != 1 {
+				b.WriteString("s")
+			}
+			fmt.Fprintf(&b, "): %s\n", group.Summary)
+		}
+		b.WriteString("\n")
+	}
 	for _, fix := range plan.Fixes {
 		fmt.Fprintf(&b, "## %s\n\n", fix.FindingID)
 		fmt.Fprintf(&b, "- Tool: `%s`\n", fix.Tool)
 		fmt.Fprintf(&b, "- Path: `%s`\n", fix.Path)
+		if fix.Server != "" {
+			fmt.Fprintf(&b, "- Server: `%s`\n", fix.Server)
+		}
 		fmt.Fprintf(&b, "- Rule: `%s`\n", fix.Rule)
+		if fix.Package != "" {
+			fmt.Fprintf(&b, "- Package: `%s`\n", fix.Package)
+		}
 		fmt.Fprintf(&b, "- Severity: `%s`\n", fix.Severity)
 		fmt.Fprintf(&b, "- Status: `%s`\n", fix.Status)
 		if fix.FixKind != "" {
@@ -172,8 +209,10 @@ func fromFinding(finding inventory.Finding) Fix {
 		FindingID:      finding.ID,
 		Tool:           finding.Tool,
 		Path:           finding.Path,
+		Server:         finding.Server,
 		Severity:       finding.Severity,
 		Rule:           finding.Rule,
+		Package:        patchPackage(finding),
 		FixAvailable:   finding.FixAvailable,
 		FixKind:        finding.FixKind,
 		Confidence:     finding.Confidence,
@@ -186,6 +225,129 @@ func fromFinding(finding inventory.Finding) Fix {
 		Impact:         finding.Impact,
 		Why:            finding.Why,
 	}
+}
+
+func patchPackage(finding inventory.Finding) string {
+	if finding.PatchHint == nil {
+		return ""
+	}
+	return finding.PatchHint.Package
+}
+
+func groupFixes(fixes []Fix) []Group {
+	byKey := map[string]*Group{}
+	for _, fix := range fixes {
+		key := fixGroupKey(fix)
+		if key == "" {
+			continue
+		}
+		group, ok := byKey[key]
+		if !ok {
+			group = &Group{
+				Key:      key,
+				Label:    fixGroupLabel(fix),
+				Rule:     fix.Rule,
+				FixKind:  fix.FixKind,
+				Package:  fix.Package,
+				Severity: fix.Severity,
+				Status:   fix.Status,
+				Summary:  fixGroupSummary(fix),
+				Steps:    fixGroupSteps(fix),
+			}
+			byKey[key] = group
+		}
+		group.Count++
+		group.FindingIDs = appendUnique(group.FindingIDs, fix.FindingID)
+		group.Paths = appendUnique(group.Paths, fix.Path)
+		group.Servers = appendUnique(group.Servers, fix.Server)
+		if riskRank(fix.Severity) > riskRank(group.Severity) {
+			group.Severity = fix.Severity
+		}
+		if statusRank(fix.Status) > statusRank(group.Status) {
+			group.Status = fix.Status
+		}
+	}
+	groups := make([]Group, 0, len(byKey))
+	for _, group := range byKey {
+		sort.Strings(group.FindingIDs)
+		sort.Strings(group.Paths)
+		sort.Strings(group.Servers)
+		groups = append(groups, *group)
+	}
+	sort.Slice(groups, func(i, j int) bool {
+		if groups[i].Count == groups[j].Count {
+			return groups[i].Key < groups[j].Key
+		}
+		return groups[i].Count > groups[j].Count
+	})
+	return groups
+}
+
+func fixGroupKey(fix Fix) string {
+	switch {
+	case fix.Rule == "mcp_unpinned_package" && fix.Package != "":
+		return "package:" + fix.Package
+	case fix.Rule == "mcp_local_endpoint":
+		return "local-endpoint:" + fix.Tool
+	case fix.Rule == "mcp_broad_filesystem":
+		return "filesystem-scope:" + fix.Tool
+	default:
+		return ""
+	}
+}
+
+func fixGroupLabel(fix Fix) string {
+	switch {
+	case fix.Rule == "mcp_unpinned_package" && fix.Package != "":
+		return "Pin " + fix.Package
+	case fix.Rule == "mcp_local_endpoint":
+		return fix.Tool + " local endpoints"
+	case fix.Rule == "mcp_broad_filesystem":
+		return fix.Tool + " filesystem scope"
+	default:
+		return fix.Rule
+	}
+}
+
+func fixGroupSummary(fix Fix) string {
+	switch {
+	case fix.Rule == "mcp_unpinned_package" && fix.Package != "":
+		return "Choose one reviewed version and apply it consistently anywhere this package executor is used."
+	case fix.Rule == "mcp_local_endpoint":
+		return "Move machine-local service assumptions into an ignored local overlay or document them as prerequisites."
+	case fix.Rule == "mcp_broad_filesystem":
+		return "Replace broad filesystem arguments with explicit reviewed paths."
+	default:
+		return fix.Summary
+	}
+}
+
+func fixGroupSteps(fix Fix) []string {
+	switch {
+	case fix.Rule == "mcp_unpinned_package" && fix.Package != "":
+		return []string{
+			"Pick a reviewed package version once.",
+			"Replace each matching package token with the same pinned version.",
+			"Rerun `nw findings list --json` and confirm the grouped unpinned-package findings are gone.",
+		}
+	case len(fix.Steps) > 0:
+		return append([]string(nil), fix.Steps...)
+	default:
+		return nil
+	}
+}
+
+func appendUnique(values []string, value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return values
+	}
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
 }
 
 func statusRank(status Status) int {

--- a/internal/fixplan/plan_test.go
+++ b/internal/fixplan/plan_test.go
@@ -29,6 +29,7 @@ func TestBuildGroupsFixStatusesAndRedacts(t *testing.T) {
 				RequiresReview: true,
 				FixSummary:     "Pin the package.",
 				FixSteps:       []string{"Change the package arg to an explicit version."},
+				PatchHint:      &inventory.PatchHint{Kind: inventory.FixPinPackage, Package: "mcp-remote"},
 			},
 			{
 				ID:             "mcp_server_review-222222222222",
@@ -58,6 +59,9 @@ func TestBuildGroupsFixStatusesAndRedacts(t *testing.T) {
 	if plan.Summary.Total != 3 || plan.Summary.Safe != 1 || plan.Summary.Review != 1 || plan.Summary.Blocked != 1 {
 		t.Fatalf("unexpected summary: %#v", plan.Summary)
 	}
+	if len(plan.Groups) != 1 || plan.Groups[0].Package != "mcp-remote" || plan.Groups[0].Count != 1 {
+		t.Fatalf("expected package group: %#v", plan.Groups)
+	}
 
 	data, err := json.Marshal(plan)
 	if err != nil {
@@ -68,8 +72,49 @@ func TestBuildGroupsFixStatusesAndRedacts(t *testing.T) {
 	}
 
 	markdown := Markdown(plan)
-	if !strings.Contains(markdown, "Nightward Fix Plan") || !strings.Contains(markdown, "Pin the package.") {
+	if !strings.Contains(markdown, "Nightward Fix Plan") || !strings.Contains(markdown, "Grouped Review") || !strings.Contains(markdown, "Pin mcp-remote") || !strings.Contains(markdown, "Pin the package.") {
 		t.Fatalf("unexpected markdown export:\n%s", markdown)
+	}
+}
+
+func TestBuildGroupsRepeatedPackagePins(t *testing.T) {
+	report := inventory.Report{Findings: []inventory.Finding{
+		{
+			ID:           "pin-a",
+			Tool:         "Cursor",
+			Path:         "/tmp/mcp.json",
+			Server:       "a",
+			Severity:     inventory.RiskHigh,
+			Rule:         "mcp_unpinned_package",
+			FixAvailable: true,
+			FixKind:      inventory.FixPinPackage,
+			PatchHint:    &inventory.PatchHint{Kind: inventory.FixPinPackage, Package: "mcp-remote"},
+			FixSummary:   "Pin mcp-remote.",
+		},
+		{
+			ID:           "pin-b",
+			Tool:         "Cursor",
+			Path:         "/tmp/mcp.json",
+			Server:       "b",
+			Severity:     inventory.RiskHigh,
+			Rule:         "mcp_unpinned_package",
+			FixAvailable: true,
+			FixKind:      inventory.FixPinPackage,
+			PatchHint:    &inventory.PatchHint{Kind: inventory.FixPinPackage, Package: "mcp-remote"},
+			FixSummary:   "Pin mcp-remote.",
+		},
+	}}
+
+	plan := Build(report, Selector{All: true})
+	if len(plan.Groups) != 1 {
+		t.Fatalf("expected one group, got %#v", plan.Groups)
+	}
+	group := plan.Groups[0]
+	if group.Count != 2 || group.Package != "mcp-remote" || len(group.FindingIDs) != 2 || len(group.Servers) != 2 {
+		t.Fatalf("unexpected package group: %#v", group)
+	}
+	if markdown := Markdown(plan); !strings.Contains(markdown, "`Pin mcp-remote` (2 findings)") {
+		t.Fatalf("markdown did not summarize grouped pins:\n%s", markdown)
 	}
 }
 

--- a/internal/inventory/mcp.go
+++ b/internal/inventory/mcp.go
@@ -30,6 +30,7 @@ type mcpServer struct {
 const maxMCPConfigBytes = 2 * 1024 * 1024
 
 var secretKeyPattern = regexp.MustCompile(`(?i)(token|secret|password|passwd|api[_-]?key|auth|credential|private[_-]?key)`)
+var providerTokenPattern = regexp.MustCompile(`(?i)^(?:sk-[a-z0-9_-]{12,}|gh[pousr]_[a-z0-9_]{20,}|glpat-[a-z0-9_-]{20,}|npm_[a-z0-9]{20,}|xox[abprs]-[a-z0-9-]{20,}|eyj[a-z0-9_-]{8,}\.[a-z0-9_-]{8,}\.[a-z0-9_-]{8,})$`)
 
 func inspectMCP(item Item, spec pathSpec) []Finding {
 	if !spec.CheckMCP || item.Kind == "directory" {
@@ -858,11 +859,37 @@ func redactArgSlice(parts []string) []string {
 			redactNext = true
 			continue
 		}
+		if providerTokenPattern.MatchString(strings.Trim(part, `"'`)) || looksOpaqueProviderToken(part) {
+			out[i] = "[redacted]"
+			continue
+		}
 		if secretKeyPattern.MatchString(part) {
 			out[i] = "[redacted]"
 		}
 	}
 	return out
+}
+
+func looksOpaqueProviderToken(part string) bool {
+	part = strings.Trim(part, `"'`)
+	if len(part) < 36 || strings.ContainsAny(part, `/\`) || strings.Contains(part, "@") || strings.Contains(part, ".") {
+		return false
+	}
+	var hasLower, hasUpper, hasDigit bool
+	for _, r := range part {
+		switch {
+		case r >= 'a' && r <= 'z':
+			hasLower = true
+		case r >= 'A' && r <= 'Z':
+			hasUpper = true
+		case r >= '0' && r <= '9':
+			hasDigit = true
+		case r == '-' || r == '_':
+		default:
+			return false
+		}
+	}
+	return hasDigit && (hasLower || hasUpper)
 }
 
 func secretAssignmentKey(part string) (string, bool) {

--- a/internal/inventory/scanner.go
+++ b/internal/inventory/scanner.go
@@ -101,32 +101,7 @@ func (s Scanner) Scan() Report {
 		report.Adapters = append(report.Adapters, status)
 	}
 
-	sort.Slice(report.Items, func(i, j int) bool {
-		if report.Items[i].Tool == report.Items[j].Tool {
-			return report.Items[i].Path < report.Items[j].Path
-		}
-		return report.Items[i].Tool < report.Items[j].Tool
-	})
-	sort.Slice(report.Findings, func(i, j int) bool {
-		if report.Findings[i].Severity == report.Findings[j].Severity {
-			return report.Findings[i].Path < report.Findings[j].Path
-		}
-		return severityRank(report.Findings[i].Severity) > severityRank(report.Findings[j].Severity)
-	})
-
-	report.Summary.TotalItems = len(report.Items)
-	report.Summary.TotalFindings = len(report.Findings)
-	for _, item := range report.Items {
-		report.Summary.ItemsByClassification[item.Classification]++
-		report.Summary.ItemsByRisk[item.Risk]++
-		report.Summary.ItemsByTool[item.Tool]++
-	}
-	for _, finding := range report.Findings {
-		report.Summary.FindingsBySeverity[finding.Severity]++
-		report.Summary.FindingsByRule[finding.Rule]++
-		report.Summary.FindingsByTool[finding.Tool]++
-	}
-
+	finalizeReport(&report)
 	return report
 }
 
@@ -200,6 +175,7 @@ func finalizeReport(report *Report) {
 	if report.SchemaVersion == 0 {
 		report.SchemaVersion = ReportSchemaVersion
 	}
+	report.Findings = collapseRedundantReviewFindings(report.Findings)
 	sort.Slice(report.Items, func(i, j int) bool {
 		if report.Items[i].Tool == report.Items[j].Tool {
 			return report.Items[i].Path < report.Items[j].Path
@@ -216,6 +192,14 @@ func finalizeReport(report *Report) {
 		return severityRank(report.Findings[i].Severity) > severityRank(report.Findings[j].Severity)
 	})
 
+	report.Summary = Summary{
+		ItemsByClassification: map[Classification]int{},
+		ItemsByRisk:           map[RiskLevel]int{},
+		ItemsByTool:           map[string]int{},
+		FindingsBySeverity:    map[RiskLevel]int{},
+		FindingsByRule:        map[string]int{},
+		FindingsByTool:        map[string]int{},
+	}
 	report.Summary.TotalItems = len(report.Items)
 	report.Summary.TotalFindings = len(report.Findings)
 	for _, item := range report.Items {
@@ -228,6 +212,33 @@ func finalizeReport(report *Report) {
 		report.Summary.FindingsByRule[finding.Rule]++
 		report.Summary.FindingsByTool[finding.Tool]++
 	}
+}
+
+func collapseRedundantReviewFindings(findings []Finding) []Finding {
+	riskyServers := map[string]bool{}
+	for _, finding := range findings {
+		if finding.Rule == "mcp_server_review" || finding.Server == "" {
+			continue
+		}
+		if severityRank(finding.Severity) > severityRank(RiskInfo) {
+			riskyServers[serverFindingKey(finding)] = true
+		}
+	}
+	if len(riskyServers) == 0 {
+		return findings
+	}
+	out := findings[:0]
+	for _, finding := range findings {
+		if finding.Rule == "mcp_server_review" && riskyServers[serverFindingKey(finding)] {
+			continue
+		}
+		out = append(out, finding)
+	}
+	return out
+}
+
+func serverFindingKey(finding Finding) string {
+	return strings.Join([]string{finding.Tool, finding.Path, finding.Server}, "\x00")
 }
 
 func inspectPath(path string, spec pathSpec) (Item, bool) {

--- a/internal/inventory/scanner_test.go
+++ b/internal/inventory/scanner_test.go
@@ -47,10 +47,13 @@ GITHUB_TOKEN = "${GITHUB_TOKEN}"
 	for _, finding := range report.Findings {
 		rules[finding.Rule] = true
 	}
-	for _, rule := range []string{"mcp_server_review", "mcp_unpinned_package", "mcp_secret_env", "mcp_broad_filesystem"} {
+	for _, rule := range []string{"mcp_unpinned_package", "mcp_secret_env", "mcp_broad_filesystem"} {
 		if !rules[rule] {
 			t.Fatalf("expected finding rule %s in %#v", rule, rules)
 		}
+	}
+	if rules["mcp_server_review"] {
+		t.Fatalf("expected redundant server-review findings to collapse when stronger server findings exist: %#v", rules)
 	}
 	var inlineSecret, envReference bool
 	for _, finding := range report.Findings {
@@ -80,6 +83,34 @@ GITHUB_TOKEN = "${GITHUB_TOKEN}"
 	}
 	if strings.Contains(string(data), "super-secret-value") {
 		t.Fatal("scan report leaked an env secret value")
+	}
+}
+
+func TestScannerKeepsReviewOnlyForServersWithoutStrongerFindings(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".mcp.json"), `{
+  "mcpServers": {
+    "review-only": {"command": "node", "args": ["server.js"]},
+    "risky": {"command": "npx", "args": ["mcp-remote"]}
+  }
+}`)
+
+	report := NewScanner(home).Scan()
+	byServerRule := map[string]map[string]bool{}
+	for _, finding := range report.Findings {
+		if byServerRule[finding.Server] == nil {
+			byServerRule[finding.Server] = map[string]bool{}
+		}
+		byServerRule[finding.Server][finding.Rule] = true
+	}
+	if !byServerRule["review-only"]["mcp_server_review"] {
+		t.Fatalf("expected review-only server to keep review finding: %#v", byServerRule)
+	}
+	if byServerRule["risky"]["mcp_server_review"] || !byServerRule["risky"]["mcp_unpinned_package"] {
+		t.Fatalf("expected risky server review finding to collapse under stronger finding: %#v", byServerRule)
+	}
+	if report.Summary.FindingsByRule["mcp_server_review"] != 1 || report.Summary.FindingsByRule["mcp_unpinned_package"] != 1 {
+		t.Fatalf("summary should reflect collapsed findings: %#v", report.Summary.FindingsByRule)
 	}
 }
 
@@ -165,11 +196,12 @@ type = "custom"
 
 func TestScannerRedactsSecretArgumentValues(t *testing.T) {
 	home := t.TempDir()
+	opaqueToken := "providerTokenValue1234567890abcdefABCDEF"
 	writeFile(t, filepath.Join(home, ".mcp.json"), `{
   "mcpServers": {
     "leaky": {
       "command": "bash",
-      "args": ["-c", "node server.js --api-key super-secret-value --token=another-secret"]
+      "args": ["-c", "node server.js --api-key super-secret-value --token=another-secret `+opaqueToken+`"]
     }
   }
 }`)
@@ -180,7 +212,7 @@ func TestScannerRedactsSecretArgumentValues(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := string(data)
-	for _, leaked := range []string{"super-secret-value", "another-secret"} {
+	for _, leaked := range []string{"super-secret-value", "another-secret", opaqueToken} {
 		if strings.Contains(text, leaked) {
 			t.Fatalf("scan report leaked secret argument value %q: %s", leaked, text)
 		}

--- a/internal/inventory/testdata/golden/scan-summary.golden.json
+++ b/internal/inventory/testdata/golden/scan-summary.golden.json
@@ -1,6 +1,6 @@
 {
   "total_items": 1,
-  "total_findings": 8,
+  "total_findings": 5,
   "items_by_classification": {
     "portable": 1
   },
@@ -12,16 +12,16 @@
   },
   "findings_by_severity": {
     "critical": 1,
-    "info": 4,
+    "info": 1,
     "medium": 3
   },
   "findings_by_rule": {
     "mcp_local_endpoint": 1,
     "mcp_secret_header": 2,
-    "mcp_server_review": 4,
+    "mcp_server_review": 1,
     "mcp_unknown_command": 1
   },
   "findings_by_tool": {
-    "Codex": 8
+    "Codex": 5
   }
 }

--- a/internal/inventory/testdata/golden/url-findings.golden.json
+++ b/internal/inventory/testdata/golden/url-findings.golden.json
@@ -30,6 +30,34 @@
     }
   },
   {
+    "id": "mcp_local_endpoint-a1016cb2257c",
+    "tool": "Codex",
+    "path": "/tmp/nightward-golden-home/.codex/config.toml",
+    "server": "local",
+    "severity": "medium",
+    "rule": "mcp_local_endpoint",
+    "message": "MCP server \"local\" points at a local or private endpoint.",
+    "evidence": "transport=remote-url type=unknown url=http://127.0.0.1:8787",
+    "recommended_action": "Keep local endpoint assumptions machine-local unless intentionally templated.",
+    "impact": "Local or private MCP endpoints may not exist on another machine and can reveal local network assumptions.",
+    "why_this_matters": "Portable dotfiles should distinguish remote service configuration from machine-local development endpoints.",
+    "fix_available": true,
+    "fix_kind": "manual-review",
+    "confidence": "medium",
+    "risk": "low",
+    "requires_review": true,
+    "fix_summary": "Move local endpoint assumptions into a machine-local overlay or document them as setup prerequisites.",
+    "fix_steps": [
+      "Confirm whether this MCP endpoint is intentionally machine-local.",
+      "Keep the URL in an ignored local overlay if it is not portable.",
+      "Document the expected local service when the endpoint is required for this machine."
+    ],
+    "patch_hint": {
+      "kind": "manual-review",
+      "replacement": "\u003creviewed-portable-or-local-overlay-url\u003e"
+    }
+  },
+  {
     "id": "mcp_secret_header-5212d7dbf262",
     "tool": "Codex",
     "path": "/tmp/nightward-golden-home/.codex/config.toml",
@@ -59,34 +87,6 @@
     }
   },
   {
-    "id": "mcp_local_endpoint-a1016cb2257c",
-    "tool": "Codex",
-    "path": "/tmp/nightward-golden-home/.codex/config.toml",
-    "server": "local",
-    "severity": "medium",
-    "rule": "mcp_local_endpoint",
-    "message": "MCP server \"local\" points at a local or private endpoint.",
-    "evidence": "transport=remote-url type=unknown url=http://127.0.0.1:8787",
-    "recommended_action": "Keep local endpoint assumptions machine-local unless intentionally templated.",
-    "impact": "Local or private MCP endpoints may not exist on another machine and can reveal local network assumptions.",
-    "why_this_matters": "Portable dotfiles should distinguish remote service configuration from machine-local development endpoints.",
-    "fix_available": true,
-    "fix_kind": "manual-review",
-    "confidence": "medium",
-    "risk": "low",
-    "requires_review": true,
-    "fix_summary": "Move local endpoint assumptions into a machine-local overlay or document them as setup prerequisites.",
-    "fix_steps": [
-      "Confirm whether this MCP endpoint is intentionally machine-local.",
-      "Keep the URL in an ignored local overlay if it is not portable.",
-      "Document the expected local service when the endpoint is required for this machine."
-    ],
-    "patch_hint": {
-      "kind": "manual-review",
-      "replacement": "\u003creviewed-portable-or-local-overlay-url\u003e"
-    }
-  },
-  {
     "id": "mcp_unknown_command-a318c5ca6d87",
     "tool": "Codex",
     "path": "/tmp/nightward-golden-home/.codex/config.toml",
@@ -111,54 +111,6 @@
     ]
   },
   {
-    "id": "mcp_server_review-895197e30eb1",
-    "tool": "Codex",
-    "path": "/tmp/nightward-golden-home/.codex/config.toml",
-    "server": "header",
-    "severity": "info",
-    "rule": "mcp_server_review",
-    "message": "Review MCP server \"header\" before syncing this config.",
-    "evidence": "transport=remote-url type=sse url=https://headers.example.test",
-    "recommended_action": "Confirm the server source, permissions, and local path assumptions.",
-    "impact": "This server may execute local code or expose local files when an AI client invokes it.",
-    "why_this_matters": "MCP configs are executable trust boundaries, so portable backups should preserve intent without hiding local-only risk.",
-    "fix_available": true,
-    "fix_kind": "ignore-with-reason",
-    "confidence": "medium",
-    "risk": "low",
-    "requires_review": true,
-    "fix_summary": "Keep the server only if its source, permissions, and local assumptions are understood.",
-    "fix_steps": [
-      "Identify the server package, binary, or script owner.",
-      "Confirm the command and arguments are expected for this machine.",
-      "Document why this server is safe to keep or exclude it from portable dotfiles."
-    ]
-  },
-  {
-    "id": "mcp_server_review-a1016cb2257c",
-    "tool": "Codex",
-    "path": "/tmp/nightward-golden-home/.codex/config.toml",
-    "server": "local",
-    "severity": "info",
-    "rule": "mcp_server_review",
-    "message": "Review MCP server \"local\" before syncing this config.",
-    "evidence": "transport=remote-url type=unknown url=http://127.0.0.1:8787",
-    "recommended_action": "Confirm the server source, permissions, and local path assumptions.",
-    "impact": "This server may execute local code or expose local files when an AI client invokes it.",
-    "why_this_matters": "MCP configs are executable trust boundaries, so portable backups should preserve intent without hiding local-only risk.",
-    "fix_available": true,
-    "fix_kind": "ignore-with-reason",
-    "confidence": "medium",
-    "risk": "low",
-    "requires_review": true,
-    "fix_summary": "Keep the server only if its source, permissions, and local assumptions are understood.",
-    "fix_steps": [
-      "Identify the server package, binary, or script owner.",
-      "Confirm the command and arguments are expected for this machine.",
-      "Document why this server is safe to keep or exclude it from portable dotfiles."
-    ]
-  },
-  {
     "id": "mcp_server_review-ebc91cff4b17",
     "tool": "Codex",
     "path": "/tmp/nightward-golden-home/.codex/config.toml",
@@ -167,30 +119,6 @@
     "rule": "mcp_server_review",
     "message": "Review MCP server \"remote\" before syncing this config.",
     "evidence": "transport=remote-url type=unknown url=https://mcp.example.test",
-    "recommended_action": "Confirm the server source, permissions, and local path assumptions.",
-    "impact": "This server may execute local code or expose local files when an AI client invokes it.",
-    "why_this_matters": "MCP configs are executable trust boundaries, so portable backups should preserve intent without hiding local-only risk.",
-    "fix_available": true,
-    "fix_kind": "ignore-with-reason",
-    "confidence": "medium",
-    "risk": "low",
-    "requires_review": true,
-    "fix_summary": "Keep the server only if its source, permissions, and local assumptions are understood.",
-    "fix_steps": [
-      "Identify the server package, binary, or script owner.",
-      "Confirm the command and arguments are expected for this machine.",
-      "Document why this server is safe to keep or exclude it from portable dotfiles."
-    ]
-  },
-  {
-    "id": "mcp_server_review-a318c5ca6d87",
-    "tool": "Codex",
-    "path": "/tmp/nightward-golden-home/.codex/config.toml",
-    "server": "unknown",
-    "severity": "info",
-    "rule": "mcp_server_review",
-    "message": "Review MCP server \"unknown\" before syncing this config.",
-    "evidence": "command=unknown",
     "recommended_action": "Confirm the server source, permissions, and local path assumptions.",
     "impact": "This server may execute local code or expose local files when an AI client invokes it.",
     "why_this_matters": "MCP configs are executable trust boundaries, so portable backups should preserve intent without hiding local-only risk.",

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -78,6 +78,31 @@ type resource struct {
 	MimeType    string `json:"mimeType,omitempty"`
 }
 
+type compactPolicyReport struct {
+	SchemaVersion    int                 `json:"schema_version"`
+	GeneratedAt      time.Time           `json:"generated_at"`
+	Strict           bool                `json:"strict"`
+	Passed           bool                `json:"passed"`
+	Threshold        inventory.RiskLevel `json:"threshold"`
+	Summary          policy.Summary      `json:"summary"`
+	Violations       []compactViolation  `json:"violations,omitempty"`
+	SignalViolations []compactViolation  `json:"signal_violations,omitempty"`
+	Truncated        bool                `json:"truncated,omitempty"`
+}
+
+type compactViolation struct {
+	ID        string              `json:"id"`
+	Rule      string              `json:"rule"`
+	Severity  inventory.RiskLevel `json:"severity"`
+	Tool      string              `json:"tool,omitempty"`
+	Provider  string              `json:"provider,omitempty"`
+	Path      string              `json:"path,omitempty"`
+	Server    string              `json:"server,omitempty"`
+	Message   string              `json:"message"`
+	Evidence  string              `json:"evidence,omitempty"`
+	Recommend string              `json:"recommended_action,omitempty"`
+}
+
 func Serve(home, version string, stdin io.Reader, stdout io.Writer) error {
 	server := Server{Home: home, Version: version, Now: time.Now}
 	return server.Serve(stdin, stdout)
@@ -222,6 +247,9 @@ func (s Server) callTool(raw json.RawMessage) (callToolResult, error) {
 			IncludeAnalysis: includeAnalysis,
 			Analysis:        analysisReport,
 		})
+		if boolArg(params.Arguments, "compact") {
+			return successToolResult(compactPolicy(policyReport, 25))
+		}
 		return successToolResult(policyReport)
 	default:
 		return callToolResult{}, fmt.Errorf("unknown tool %q", params.Name)
@@ -279,7 +307,7 @@ func mcpTools() []tool {
 		{Name: "nightward_explain_finding", Title: "Explain Finding", Description: "Return a single Nightward finding by full ID or unique prefix.", InputSchema: requiredObjectSchema(map[string]any{"workspace": stringSchema("Optional workspace/repository path."), "finding_id": stringSchema("Finding ID or unique prefix.")}, []string{"finding_id"}), Annotations: readOnly},
 		{Name: "nightward_fix_plan", Title: "Generate Fix Plan", Description: "Generate plan-only remediation output for all findings or a selected finding/rule.", InputSchema: objectSchema(map[string]any{"workspace": stringSchema("Optional workspace/repository path."), "finding_id": stringSchema("Optional finding ID or unique prefix."), "rule": stringSchema("Optional rule ID."), "all": map[string]any{"type": "boolean", "description": "Include all findings."}}), Annotations: readOnly},
 		{Name: "nightward_report_changes", Title: "Compare Latest Reports", Description: "Compare the latest two saved Nightward reports and return added, removed, and changed findings.", InputSchema: objectSchema(map[string]any{"report_dir": stringSchema("Optional report directory. Defaults to Nightward state reports.")}), Annotations: readOnly},
-		{Name: "nightward_policy_check", Title: "Check Policy", Description: "Run the local policy gate with optional offline analysis. Online providers are not enabled through MCP v1.", InputSchema: objectSchema(map[string]any{"workspace": stringSchema("Optional workspace/repository path."), "strict": map[string]any{"type": "boolean", "description": "Fail on medium or higher findings."}, "include_analysis": map[string]any{"type": "boolean", "description": "Include offline analysis signals."}, "providers": map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Offline providers to request for analysis."}}), Annotations: readOnly},
+		{Name: "nightward_policy_check", Title: "Check Policy", Description: "Run the local policy gate with optional offline analysis. Online providers are not enabled through MCP v1.", InputSchema: objectSchema(map[string]any{"workspace": stringSchema("Optional workspace/repository path."), "strict": map[string]any{"type": "boolean", "description": "Fail on medium or higher findings."}, "include_analysis": map[string]any{"type": "boolean", "description": "Include offline analysis signals."}, "compact": map[string]any{"type": "boolean", "description": "Return a compact AI-client friendly policy summary instead of full violations."}, "providers": map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Offline providers to request for analysis."}}), Annotations: readOnly},
 	}
 }
 
@@ -403,6 +431,57 @@ func bounded(kind string, value any) any {
 			"message":   "Output exceeded the Nightward MCP safety cap.",
 		}
 	}
+}
+
+func compactPolicy(report policy.Report, limit int) compactPolicyReport {
+	if limit <= 0 {
+		limit = 25
+	}
+	out := compactPolicyReport{
+		SchemaVersion: report.SchemaVersion,
+		GeneratedAt:   report.GeneratedAt,
+		Strict:        report.Strict,
+		Passed:        report.Passed,
+		Threshold:     report.Threshold,
+		Summary:       report.Summary,
+	}
+	for _, finding := range report.Violations {
+		if len(out.Violations) >= limit {
+			out.Truncated = true
+			break
+		}
+		out.Violations = append(out.Violations, compactViolation{
+			ID:        finding.ID,
+			Rule:      finding.Rule,
+			Severity:  finding.Severity,
+			Tool:      finding.Tool,
+			Path:      finding.Path,
+			Server:    finding.Server,
+			Message:   finding.Message,
+			Evidence:  finding.Evidence,
+			Recommend: finding.Recommendation,
+		})
+	}
+	for _, signal := range report.SignalViolations {
+		if len(out.SignalViolations) >= limit {
+			out.Truncated = true
+			break
+		}
+		out.SignalViolations = append(out.SignalViolations, compactViolation{
+			ID:        signal.ID,
+			Rule:      signal.Rule,
+			Severity:  signal.Severity,
+			Provider:  signal.Provider,
+			Path:      signal.Path,
+			Message:   signal.Message,
+			Evidence:  signal.Evidence,
+			Recommend: signal.Recommendation,
+		})
+	}
+	if len(report.Violations) > len(out.Violations) || len(report.SignalViolations) > len(out.SignalViolations) {
+		out.Truncated = true
+	}
+	return out
 }
 
 func filterFindings(findings []inventory.Finding, args map[string]any) []inventory.Finding {

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -222,6 +222,7 @@ func TestFindingExplainReportChangesAndPolicyTool(t *testing.T) {
 		`{"jsonrpc":"2.0","id":"required","method":"tools/call","params":{"name":"nightward_explain_finding","arguments":{}}}`,
 		`{"jsonrpc":"2.0","id":"diff","method":"tools/call","params":{"name":"nightward_report_changes","arguments":{}}}`,
 		`{"jsonrpc":"2.0","id":"policy","method":"tools/call","params":{"name":"nightward_policy_check","arguments":{"strict":true,"include_analysis":true,"providers":"missing-provider"}}}`,
+		`{"jsonrpc":"2.0","id":"policy-compact","method":"tools/call","params":{"name":"nightward_policy_check","arguments":{"strict":true,"include_analysis":true,"compact":true}}}`,
 	}, "\n") + "\n"
 	var out bytes.Buffer
 	if err := server.Serve(strings.NewReader(input), &out); err != nil {
@@ -251,6 +252,13 @@ func TestFindingExplainReportChangesAndPolicyTool(t *testing.T) {
 	policyReport := toolJSON(t, responses[5])
 	if policyReport["schema_version"] == nil {
 		t.Fatalf("expected policy report JSON, got %#v", policyReport)
+	}
+	compactPolicyReport := toolJSON(t, responses[6])
+	if compactPolicyReport["summary"] == nil || compactPolicyReport["threshold"] == nil {
+		t.Fatalf("expected compact policy summary, got %#v", compactPolicyReport)
+	}
+	if _, ok := compactPolicyReport["ignored"]; ok {
+		t.Fatalf("compact policy should omit full ignored policy detail, got %#v", compactPolicyReport)
 	}
 }
 

--- a/site/integrations/mcp-server.md
+++ b/site/integrations/mcp-server.md
@@ -20,6 +20,11 @@ The server exposes Nightward context to AI tools without opening a network liste
 | `nightward_report_changes` | Compare the latest two saved report JSON files. |
 | `nightward_policy_check` | Run the policy gate with optional offline analysis. |
 
+For chat-oriented policy checks, pass `compact: true` to
+`nightward_policy_check`. Compact mode returns pass/fail, threshold, summary
+counts, and bounded violation metadata without flooding the client with every
+full finding.
+
 ## Resources
 
 - `nightward://rules`
@@ -52,5 +57,7 @@ Claude Code and other local AI clients can use the same command/args shape when 
 - No live config mutation or schedule install/remove tools.
 - Tool output is bounded and redacted before it reaches the MCP client.
 - Tool failures are returned as MCP tool results with `isError`, so the client can show the error without treating it as a protocol failure.
+- Compact policy output is available for quick AI-client status checks; full
+  policy output remains available for local review.
 
 Use explicit CLI commands such as `nw analyze --with trivy --online --json` outside MCP when you intentionally want online provider execution.

--- a/site/integrations/raycast.md
+++ b/site/integrations/raycast.md
@@ -5,7 +5,7 @@ Nightward's Raycast extension is a read-only macOS companion for checking AI-age
 ## Commands
 
 - Dashboard.
-- Findings.
+- Findings with scoped fix-plan exports and reviewed-policy-ignore snippets.
 - Analysis.
 - Provider Doctor with provider enable/disable controls for Raycast Analysis.
 - Explain Finding.
@@ -17,7 +17,7 @@ Nightward's Raycast extension is a read-only macOS companion for checking AI-age
 
 The extension shells out to `nw` or `nightward`, renders redacted output, and never mutates agent configs.
 
-The dashboard and menu-bar status include scheduled report counts when `nw doctor --json` reports history. They can also reveal or open the latest report when one exists, so users can move from the menu-bar counter to the underlying local JSON quickly.
+The dashboard and menu-bar status include scheduled report counts when `nw doctor --json` reports history. The menu-bar title stays compact (`3C`, `18H`, or a total count), while the dropdown shows critical/high/total counts, provider warnings, and latest-report links.
 
 ## Preferences
 
@@ -26,6 +26,11 @@ The dashboard and menu-bar status include scheduled report counts when `nw docto
 - `Allow Online Providers`: enables selected online-capable providers in Raycast Analysis. Leave it off for local-only behavior.
 
 Provider Doctor can select `gitleaks`, `trufflehog`, `semgrep`, `trivy`, `osv-scanner`, and `socket` for the Analysis command. Online-capable selections stay blocked until `Allow Online Providers` is enabled; Socket creates a remote scan artifact when it runs.
+
+Findings actions remain plan-only: users can copy a redacted fix plan for the
+selected finding, copy a grouped rule-level fix plan, or copy a policy-ignore
+snippet with a reason placeholder. The extension does not write policy files or
+mutate MCP configs.
 
 ## Store Readiness
 


### PR DESCRIPTION
## Summary
- collapse redundant info-only MCP review findings when the same server already has a stronger finding
- group repeated remediation work in fix plans, especially package pinning and local endpoint review
- add compact MCP policy output for AI-client usage
- improve Raycast menu-bar/status text, scoped fix-plan exports, reviewed-ignore snippets, and redaction

## What changed
- added scanner post-processing to reduce duplicate `mcp_server_review` noise while preserving standalone review-only findings
- expanded fix-plan JSON/Markdown with grouped review metadata and repeated-package context
- added provider-token and opaque-token redaction across core analysis, inventory parsing, and Raycast formatting
- added `compact` support to `nightward_policy_check` in the MCP server
- updated Raycast commands/tests/docs for concise status, finding-scoped fix-plan copy, rule-scoped fix-plan copy, and policy-ignore snippet copy
- refreshed docs/site/Raycast README/changelog coverage for the new dogfood flows

## Why
Local dogfooding showed that Nightward was finding real MCP and dotfiles risk, but repeated review findings, ungrouped fix plans, bulky MCP policy output, and weak Raycast actions made the remediation loop noisier than it needed to be. This keeps all remediation plan-only and read-only while making the output easier to act on.

## Validation
- `make test-prepush`
- `git diff --check`

## Notes
- No local HOME config mutation was performed. The real-machine findings still require explicit human approval before editing local AI-tool configs.
- `make test-prepush` includes `make verify`, Raycast lint/build/audit, npm package verification, site verification, Trunk, gitleaks, govulncheck, gosec, fuzz smoke, and coverage checks.
- Raycast Store submission still needs metadata screenshots/manual evidence; this PR improves the extension behavior but does not submit it upstream.