### PR TITLE
fix(redaction): fully redact whitespace-separated auth credentials

### DIFF
--- a/crates/nightward-core/src/inventory.rs
+++ b/crates/nightward-core/src/inventory.rs
@@ -787,7 +787,7 @@ pub fn redact_text(value: &str) -> String {
     ))
     .expect("valid regex");
     let assignment = Regex::new(&format!(
-        r#"(?i)([\w.-]*{sensitive_key}[\w.-]*\s*[:=]\s*)(?:\$\{{[A-Za-z_][A-Za-z0-9_]*\}}|[^\s\r\n,}}]+)"#
+        r#"(?i)([\w.-]*{sensitive_key}[\w.-]*\s*[:=]\s*)(?:\$\{{[A-Za-z_][A-Za-z0-9_]*\}}|[^\s\r\n,}}]+(?:\s+[^\s\r\n,}}]+)?)"#
     ))
         .expect("valid regex");
     let provider = Regex::new(r"(?i)\b(?:Bearer\s+[-A-Za-z0-9._~+/=]{8,}|sk-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9_]{20,}|glpat-[A-Za-z0-9_-]{20,}|npm_[A-Za-z0-9]{20,}|xox[abprs]-[A-Za-z0-9-]{20,}|eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,})\b")
@@ -913,6 +913,15 @@ mod tests {
         let redacted = redact_text(&evidence);
 
         assert_eq!(redacted, "env.API_TOKEN=[redacted]");
+    }
+
+    #[test]
+    fn redacts_basic_auth_values_after_sensitive_keys() {
+        let token = ["dXNlcjpw", "YXNz"].concat();
+        let redacted = redact_text(&format!("Authorization: Basic {token}"));
+
+        assert_eq!(redacted, "Authorization: [redacted]");
+        assert!(!redacted.contains(&token));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- A recent change to `redact_text` stopped assignment redaction at the first whitespace, which left credential tokens in values like `Authorization: Basic <credential>` unredacted and leaked into report evidence.

### Description
- Adjusted the unquoted assignment regex in `redact_text` to allow an optional second whitespace-delimited token so two-part auth schemes (e.g., `Basic <credential>`) are fully consumed and redacted.
- Kept existing provider-specific redaction intact (e.g., `Bearer` and known token shapes) and preserved surrounding context behavior (so unrelated trailing text like paths remain visible).
- Added a focused regression test `redacts_basic_auth_values_after_sensitive_keys` to ensure `Authorization: Basic ...` values are fully redacted.

### Testing
- Ran the unit tests for the core crate focusing on redaction with `cargo test -p nightward-core redacts_`, and the redaction-related tests passed (`6 passed; 0 failed`).
- The new regression test `redacts_basic_auth_values_after_sensitive_keys` was executed as part of that run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c5d97408832c8c3322dc8aff4b5f)