### PR TITLE
fix(core): drain provider pipes while waiting for timeout

### DIFF
--- a/crates/nightward-core/src/providers.rs
+++ b/crates/nightward-core/src/providers.rs
@@ -8,6 +8,7 @@ use std::env;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::thread;
 use std::time::Duration;
 use wait_timeout::ChildExt;
 
@@ -161,6 +162,28 @@ pub fn run_provider(name: &str, root: &Path) -> Result<Vec<ProviderFinding>> {
         .stderr(Stdio::piped())
         .spawn()
         .with_context(|| format!("spawn provider {name}"))?;
+
+    let stdout_handle = child.stdout.take().map(|mut stream| {
+        thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = stream
+                .by_ref()
+                .take(stdout_cap as u64 + 1)
+                .read_to_end(&mut buf);
+            buf
+        })
+    });
+    let stderr_handle = child.stderr.take().map(|mut stream| {
+        thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = stream
+                .by_ref()
+                .take(stderr_cap as u64 + 1)
+                .read_to_end(&mut buf);
+            buf
+        })
+    });
+
     let status = match child.wait_timeout(timeout)? {
         Some(status) => status,
         None => {
@@ -169,20 +192,13 @@ pub fn run_provider(name: &str, root: &Path) -> Result<Vec<ProviderFinding>> {
             return Err(anyhow!("provider timed out after {:?}", timeout));
         }
     };
-    let mut stdout = Vec::new();
-    let mut stderr = Vec::new();
-    if let Some(mut stream) = child.stdout.take() {
-        let _ = stream
-            .by_ref()
-            .take(stdout_cap as u64 + 1)
-            .read_to_end(&mut stdout);
-    }
-    if let Some(mut stream) = child.stderr.take() {
-        let _ = stream
-            .by_ref()
-            .take(stderr_cap as u64 + 1)
-            .read_to_end(&mut stderr);
-    }
+
+    let stdout = stdout_handle
+        .map(|handle| handle.join().unwrap_or_default())
+        .unwrap_or_default();
+    let stderr = stderr_handle
+        .map(|handle| handle.join().unwrap_or_default())
+        .unwrap_or_default();
     let (stdout, stdout_truncated) = capped_string(stdout, stdout_cap);
     let (stderr, _) = capped_string(stderr, stderr_cap);
     if stdout_truncated {

--- a/crates/nightward-core/tests/provider_contracts.rs
+++ b/crates/nightward-core/tests/provider_contracts.rs
@@ -91,12 +91,15 @@ fn provider_timeout_returns_stable_warning_error() {
         ("NIGHTWARD_PROVIDER_STDOUT_CAP", None),
     ]);
     let dir = tempfile::tempdir().expect("temp dir");
-    write_executable(dir.path().join("gitleaks"), "#!/bin/sh\nsleep 1\n");
+    write_executable(dir.path().join("gitleaks"), "#!/bin/sh\n/bin/sleep 1\n");
     std::env::set_var("PATH", dir.path());
 
     let error = run_provider("gitleaks", dir.path()).expect_err("timeout");
 
-    assert!(error.to_string().contains("provider timed out after"));
+    assert!(
+        error.to_string().contains("provider timed out after"),
+        "actual error: {error}"
+    );
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
### Motivation
- The provider runner waited for the child process to exit before reading piped `stdout`/`stderr`, which can deadlock when a provider emits more data than the OS pipe buffer and causes findings to be lost. 
- This behavior converts a timed-out or killed provider into a low-severity `provider_execution_failed` signal, allowing explicitly enabled providers to be silently bypassed by large outputs. 
- The intent of the change is to ensure provider output is drained while the child runs so caps and timeouts behave as intended and provider findings are not suppressed. 

### Description
- Drain `stdout` and `stderr` concurrently by spawning reader threads that `read_to_end` (with `take`-based caps) immediately after spawning the provider, and join those threads after `wait_timeout` returns. 
- Preserve existing output-cap behavior and timeout handling, returning the same capped error when `stdout` exceeds the configured cap or the provider times out. 
- Add `use std::thread;` and update the provider contract test to invoke `/bin/sleep` under an isolated `PATH` and to include the actual error text in the assertion message. 
- Modified files: `crates/nightward-core/src/providers.rs` and `crates/nightward-core/tests/provider_contracts.rs`. 

### Testing
- Ran `cargo test -p nightward-core`, which executes the unit tests and `provider_contracts` test suite. 
- The `provider_contracts` tests (including `provider_timeout_returns_stable_warning_error` and `provider_stdout_cap_fails_closed_before_parsing`) passed after the changes. 
- All core tests completed with no failures in the final run. 
- The change preserves existing caps and timeout semantics verified by the updated tests using the isolated provider stubs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c0b0d528832c85370ab4747290dc)