### PR TITLE
fix(release): select host archive in release smoke

### DIFF
--- a/scripts/smoke-release-archive.sh
+++ b/scripts/smoke-release-archive.sh
@@ -8,8 +8,29 @@ if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   exit 1
 fi
 version="${tag#v}"
-asset="nightward_${version}_linux_amd64.tar.gz"
-sbom="nightward_${version}_linux_amd64.sbom.json"
+case "$(uname -s)" in
+  Darwin) os="darwin" ;;
+  Linux) os="linux" ;;
+  MINGW* | MSYS* | CYGWIN*) os="windows" ;;
+  *)
+    echo "unsupported release smoke OS: $(uname -s)" >&2
+    exit 1
+    ;;
+esac
+case "$(uname -m)" in
+  x86_64 | amd64) arch="amd64" ;;
+  arm64 | aarch64) arch="arm64" ;;
+  *)
+    echo "unsupported release smoke architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+if [[ "${os}" == "windows" ]]; then
+  asset="nightward_${version}_${os}_${arch}.zip"
+else
+  asset="nightward_${version}_${os}_${arch}.tar.gz"
+fi
+sbom="nightward_${version}_${os}_${arch}.sbom.json"
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "${tmp_dir}"' EXIT
 
@@ -30,10 +51,16 @@ cosign verify-blob \
   checksums.txt
 sha256sum -c checksums.txt --ignore-missing
 mkdir -p extracted
-tar -xzf "${asset}" -C extracted
+if [[ "${asset}" == *.zip ]]; then
+  unzip -q "${asset}" -d extracted
+  bin_ext=".exe"
+else
+  tar -xzf "${asset}" -C extracted
+  bin_ext=""
+fi
 
 cd extracted
-./nightward --version | grep -Fx "${version}"
-./nw --version | grep -Fx "${version}"
+./nightward"${bin_ext}" --version | grep -Fx "${version}"
+./nw"${bin_ext}" --version | grep -Fx "${version}"
 
 echo "release archive smoke passed for ${repo}@${tag}"

--- a/scripts/test-release-scripts.sh
+++ b/scripts/test-release-scripts.sh
@@ -9,6 +9,12 @@ if "${repo_root}/scripts/smoke-release-archive.sh" "latest" >/dev/null 2>&1; the
   echo "expected smoke-release-archive.sh to reject non-semver tag" >&2
   exit 1
 fi
+grep -q 'uname -s' "${repo_root}/scripts/smoke-release-archive.sh"
+grep -q 'uname -m' "${repo_root}/scripts/smoke-release-archive.sh"
+if grep -q 'nightward_${version}_linux_amd64.tar.gz' "${repo_root}/scripts/smoke-release-archive.sh"; then
+  echo "expected smoke-release-archive.sh to select the host release archive" >&2
+  exit 1
+fi
 
 if "${repo_root}/scripts/verify-npm-release.sh" "v0.1.0" >/dev/null 2>&1; then
   echo "expected verify-npm-release.sh to reject v-prefixed npm version" >&2


### PR DESCRIPTION
## Summary
- install/use local cosign-compatible release smoke path by making the script select the host archive
- keep CI behavior on Linux while allowing macOS arm64 local release smoke to execute the matching release binary

## What changed
- map uname OS/architecture to Nightward release asset names
- support tar.gz archives for Linux/macOS and zip archives for Windows shell environments
- add release-script fixture checks against hardcoded linux_amd64 smoke assets

## Why
- local release verification should work without bypasses; after installing cosign, the previous script still downloaded a Linux amd64 binary that cannot execute on this macOS arm64 machine

## Validation
- cosign version
- bash scripts/test-release-scripts.sh
- bash scripts/smoke-release-archive.sh v0.1.8
- trunk check --show-existing --fix --all
- trunk check --show-existing --all
