### PR TITLE
fix(release): stamp mcp registry metadata for npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,6 +251,9 @@ jobs:
           cd packages/npm
           npm ci --ignore-scripts --no-audit
           npm version --no-git-tag-version "${version}"
+          cd ../..
+          node scripts/stamp-mcp-registry-version.mjs "${version}"
+          cd packages/npm
           npm test
           npm audit --audit-level=moderate
           npm pack --dry-run

--- a/scripts/stamp-mcp-registry-version.mjs
+++ b/scripts/stamp-mcp-registry-version.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const version = process.argv[2];
+
+if (!version || !/^[0-9]+\.[0-9]+\.[0-9]+$/.test(version)) {
+  throw new Error("usage: stamp-mcp-registry-version.mjs <x.y.z>");
+}
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(process.env.NIGHTWARD_REPO_ROOT ?? join(scriptDir, ".."));
+const serverPath = join(repoRoot, "server.json");
+const npmPackagePath = join(repoRoot, "packages", "npm", "package.json");
+
+function readJSON(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+const server = readJSON(serverPath);
+const npmPackage = readJSON(npmPackagePath);
+
+if (npmPackage.version !== version) {
+  throw new Error(
+    `packages/npm/package.json is ${npmPackage.version}, expected ${version}`,
+  );
+}
+
+if (server.name !== npmPackage.mcpName) {
+  throw new Error(`server.json name ${server.name} does not match npm mcpName`);
+}
+
+const targets = server.packages?.filter(
+  (entry) =>
+    entry?.registryType === "npm" && entry?.identifier === npmPackage.name,
+);
+
+if (!targets || targets.length !== 1) {
+  throw new Error(
+    `expected one npm package target for ${npmPackage.name} in server.json`,
+  );
+}
+
+server.version = version;
+targets[0].version = version;
+
+writeFileSync(serverPath, `${JSON.stringify(server, null, 2)}\n`);
+console.log(`stamped MCP registry metadata to ${version}`);

--- a/scripts/test-release-scripts.sh
+++ b/scripts/test-release-scripts.sh
@@ -37,6 +37,7 @@ if [[ "$(grep -c "validate-release-ref.sh" "${repo_root}/.github/workflows/relea
   echo "expected release workflow to enforce release ref validation before publishing" >&2
   exit 1
 fi
+grep -q "stamp-mcp-registry-version.mjs" "${repo_root}/.github/workflows/release.yml"
 grep -q "ubuntu-24.04-arm" "${repo_root}/.github/workflows/release.yml"
 grep -q "macos-15-intel" "${repo_root}/.github/workflows/release.yml"
 grep -q "aarch64-unknown-linux-gnu" "${repo_root}/.github/workflows/release.yml"
@@ -52,6 +53,43 @@ if grep -q "path: dist/nightward_\\*" "${repo_root}/.github/workflows/release.ym
   echo "expected release upload to exclude staging directories" >&2
   exit 1
 fi
+
+if node "${repo_root}/scripts/stamp-mcp-registry-version.mjs" "v0.1.0" >/dev/null 2>&1; then
+  echo "expected stamp-mcp-registry-version.mjs to reject v-prefixed versions" >&2
+  exit 1
+fi
+
+mkdir -p "${tmp}/stamp/packages/npm"
+cat >"${tmp}/stamp/server.json" <<'JSON'
+{
+  "name": "io.github.jsonbored/nightward",
+  "version": "0.0.0-development",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@jsonbored/nightward",
+      "version": "0.0.0-development",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}
+JSON
+cat >"${tmp}/stamp/packages/npm/package.json" <<'JSON'
+{
+  "name": "@jsonbored/nightward",
+  "version": "0.1.10",
+  "mcpName": "io.github.jsonbored/nightward"
+}
+JSON
+NIGHTWARD_REPO_ROOT="${tmp}/stamp" node "${repo_root}/scripts/stamp-mcp-registry-version.mjs" "0.1.10" >/dev/null
+node -e '
+const { readFileSync } = require("node:fs");
+const server = JSON.parse(readFileSync(process.argv[1], "utf8"));
+if (server.version !== "0.1.10") throw new Error("server version was not stamped");
+if (server.packages[0].version !== "0.1.10") throw new Error("package target was not stamped");
+' "${tmp}/stamp/server.json"
 
 mkdir -p "${tmp}/target/release"
 printf '#!/usr/bin/env bash\nprintf "0.1.0\\n"\n' >"${tmp}/target/release/nightward"


### PR DESCRIPTION
## Summary
- fix the npm release job that failed after `v0.1.9` by stamping MCP registry metadata to the release version before npm tests and packing

## What changed
- added `scripts/stamp-mcp-registry-version.mjs`
- updated the release workflow to stamp `server.json` after `npm version`
- added release-script fixture coverage for the stamp path and v-prefixed version rejection

## Why
- `packages/npm/package.json` is release-stamped during publish, but `server.json` remained `0.0.0-development`, causing the MCP registry contract test to fail before npm publish

## Validation
- `make verify`
- `make ci-scripts-test`
- `make npm-package-verify`
- temp-copy release sequence: `npm version --no-git-tag-version 0.1.10`, `node scripts/stamp-mcp-registry-version.mjs 0.1.10`, `npm test`, `npm pack --dry-run`
- `git diff --check`

## Notes
- `v0.1.9` GitHub release was created and verified, but npm publish failed before publication. After this merges, cut a new `v0.1.10` tag instead of reusing `v0.1.9`.
